### PR TITLE
Allow users to override sdk_version_json during build

### DIFF
--- a/intrinsic_sdk_cmake/cmake/fetch_sdk.cmake
+++ b/intrinsic_sdk_cmake/cmake/fetch_sdk.cmake
@@ -1,6 +1,7 @@
 # Fetch the sdk and make it available for use locally.
 
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_version.json" sdk_version_json)
+set(SDK_VERSION_JSON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_version.json")
+file(READ "${SDK_VERSION_JSON_FILE}" sdk_version_json)
 string(JSON sdk_version GET ${sdk_version_json} "sdk_version")
 message(STATUS "intrinsic-ai/sdk version: ${sdk_version}")
 


### PR DESCRIPTION
So that downstream users can maintain their own `sdk_version.json` depending on what version of the platform they are using. Open to other suggestions! 