### PR TITLE
Fail executive when a process is not found

### DIFF
--- a/flowstate_ros_bridge/src/bridges/executive_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/executive_bridge.cpp
@@ -226,6 +226,11 @@ bool ExecutiveBridge::initialize(ROSNodeInterfaces ros_node_interfaces,
             result->message = start_result.status().ToString();
             goal_handle->abort(std::move(result));
           }
+        } else {
+          auto result = std::make_shared<StartProcess::Result>();
+          result->success = false;
+          result->message = "Process not found";
+          goal_handle->abort(std::move(result));
         }
       });
 


### PR DESCRIPTION
Previously, if the call to fetch a behavior tree failed the goal callback would return without actually sending a result, which would make it fail with an empty message.
I just added an `else` statement to make sure users get a message that tells them why process execution failed.