### PR TITLE
Update joint_states topic with override-able joint names

### DIFF
--- a/flowstate_ros_bridge/docs/robot_state_sensor.md
+++ b/flowstate_ros_bridge/docs/robot_state_sensor.md
@@ -73,7 +73,7 @@ These parameters are defined in the `SensorPublisherConfig` message and can be m
 | `force_torque_sensor_frame_id` | `/force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor` | Frame ID of F/T sensor to be used in force_torque_topic. |
 | `robot_controller_instance` | `robot_controller` | Name of the ICON service/resource instance. |
 | `throttle_robot_state_topic` | `false` | By default, the bridge subscribes to the high-frequency `/icon/robot_controller/robot_status` state topic (~300 Hz). If this parameter is set to `True`, then the low-frequency equivalent (~25 Hz), topic  `/icon/robot_controller/robot_status_throttle`, will be used instead. |
-
+| `override_joint_names` | `[]` | If populated, replaces the default joint names with a user-specified ones. The size of override_joint_names must match the number of joints of the robot part it is overriding, otherwise it will be ignored. Example values for a 6 DOF robot such as the UR5e would be `["shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", "wrist_1_joint", "wrist_2_joint", "wrist_3_joint"]"`. |
 ---
 
 ## 3. Usage & Verification

--- a/flowstate_ros_bridge/docs/robot_state_sensor.md
+++ b/flowstate_ros_bridge/docs/robot_state_sensor.md
@@ -67,8 +67,8 @@ These parameters are defined in the `SensorPublisherConfig` message and can be m
 | :--- | :--- | :--- |
 | `enable_robot_joint_state_topic` | `true` | Enables publishing of robot joint states in ROS. |
 | `enable_force_torque_topic` | `true` | Enables publishing of F/T sensor data in ROS. |
-| `robot_joint_state_topic` | `/robot_joint_state` | Topic to publish joint state data on. |
-| `force_torque_topic` | `/force_torque_sensor` | Topic to publish F/T sensor data on. |
+| `robot_joint_state_topic` | `/joint_states` | Topic to publish joint state data on. |
+| `force_torque_topic` | `/fts_broadcaster/wrench` | Topic to publish F/T sensor data on. |
 | `force_torque_sensor_frame_id` | `force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor` | Frame ID of F/T sensor to be used in force_torque_topic. |
 | `robot_controller_instance` | `robot_controller` | Name of the ICON service/resource instance. |
 | `throttle_robot_state_topic` | `false` | By default, the bridge subscribes to the high-frequency `/icon/robot_controller/robot_status` state topic (~300 Hz). If this parameter is set to `True`, then the low-frequency equivalent (~25 Hz), topic  `/icon/robot_controller/robot_status_throttle`, will be used instead. |

--- a/flowstate_ros_bridge/docs/robot_state_sensor.md
+++ b/flowstate_ros_bridge/docs/robot_state_sensor.md
@@ -69,7 +69,8 @@ These parameters are defined in the `SensorPublisherConfig` message and can be m
 | `enable_force_torque_topic` | `true` | Enables publishing of F/T sensor data in ROS. |
 | `robot_joint_state_topic` | `/joint_states` | Topic to publish joint state data on. |
 | `force_torque_topic` | `/fts_broadcaster/wrench` | Topic to publish F/T sensor data on. |
-| `force_torque_sensor_frame_id` | `force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor` | Frame ID of F/T sensor to be used in force_torque_topic. |
+| `robot_base_frame_id` | `/robot/robot/base_link` | Frame ID of robot base to be used in robot_joint_state_topic. |
+| `force_torque_sensor_frame_id` | `/force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor` | Frame ID of F/T sensor to be used in force_torque_topic. |
 | `robot_controller_instance` | `robot_controller` | Name of the ICON service/resource instance. |
 | `throttle_robot_state_topic` | `false` | By default, the bridge subscribes to the high-frequency `/icon/robot_controller/robot_status` state topic (~300 Hz). If this parameter is set to `True`, then the low-frequency equivalent (~25 Hz), topic  `/icon/robot_controller/robot_status_throttle`, will be used instead. |
 

--- a/flowstate_ros_bridge/flowstate_ros_bridge.proto
+++ b/flowstate_ros_bridge/flowstate_ros_bridge.proto
@@ -27,5 +27,5 @@ message FlowstateRosBridgeConfig {
   repeated string bridge_plugins = 9;
   int64 executive_deadline_seconds = 10;
   int64 executive_update_rate_millis = 11;
-  SensorPublisherConfig sensors = 14;
+  SensorPublisherConfig sensors = 12;
 }

--- a/flowstate_ros_bridge/flowstate_ros_bridge.proto
+++ b/flowstate_ros_bridge/flowstate_ros_bridge.proto
@@ -13,6 +13,7 @@ message SensorPublisherConfig {
   string force_torque_sensor_frame_id = 6;
   string robot_controller_instance = 7;
   bool throttle_robot_state_topic = 8;
+  repeated string override_joint_names = 9;
 }
 
 message FlowstateRosBridgeConfig {

--- a/flowstate_ros_bridge/flowstate_ros_bridge.proto
+++ b/flowstate_ros_bridge/flowstate_ros_bridge.proto
@@ -9,9 +9,10 @@ message SensorPublisherConfig {
   bool enable_force_torque_topic = 2;
   string robot_joint_state_topic = 3;
   string force_torque_topic = 4;
-  string force_torque_sensor_frame_id = 5;
-  string robot_controller_instance = 6;
-  bool throttle_robot_state_topic = 7;
+  string robot_base_frame_id = 5;
+  string force_torque_sensor_frame_id = 6;
+  string robot_controller_instance = 7;
+  bool throttle_robot_state_topic = 8;
 }
 
 message FlowstateRosBridgeConfig {

--- a/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
@@ -13,7 +13,7 @@
   bridge_plugins: [
     "flowstate_ros_bridge::WorldBridge",
     "flowstate_ros_bridge::ExecutiveBridge"
-  ],
+  ]
   executive_deadline_seconds: 5
   executive_update_rate_millis: 1000
   sensors: {
@@ -25,5 +25,6 @@
     force_torque_sensor_frame_id: "force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor"
     robot_controller_instance: "robot_controller"
     throttle_robot_state_topic: false
+    override_joint_names: []
   },
 }

--- a/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
@@ -19,8 +19,8 @@
   sensors: {
     enable_robot_joint_state_topic: true
     enable_force_torque_topic: true
-    robot_joint_state_topic: "/robot_joint_state"
-    force_torque_topic: "/force_torque_sensor"
+    robot_joint_state_topic: "/joint_states"
+    force_torque_topic: "/fts_broadcaster/wrench"
     force_torque_sensor_frame_id: "force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor"
     robot_controller_instance: "robot_controller"
     throttle_robot_state_topic: false

--- a/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
@@ -21,6 +21,7 @@
     enable_force_torque_topic: true
     robot_joint_state_topic: "/joint_states"
     force_torque_topic: "/fts_broadcaster/wrench"
+    robot_base_frame_id: "/robot/robot/base_link"
     force_torque_sensor_frame_id: "force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor"
     robot_controller_instance: "robot_controller"
     throttle_robot_state_topic: false

--- a/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
@@ -21,7 +21,7 @@
     enable_force_torque_topic: true
     robot_joint_state_topic: "/joint_states"
     force_torque_topic: "/fts_broadcaster/wrench"
-    robot_base_frame_id: "/robot/robot/base_link"
+    robot_base_frame_id: "robot/robot/base_link"
     force_torque_sensor_frame_id: "force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor"
     robot_controller_instance: "robot_controller"
     throttle_robot_state_topic: false

--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -40,6 +40,7 @@ constexpr const char* kRobotJointStateTopicParamName =
 constexpr const char* kForceTorqueTopicParamName = "force_torque_topic";
 constexpr const char* kForceTorqueSensorFrameIDParamName =
     "force_torque_sensor_frame_id";
+constexpr const char* kRobotBaseFrameIDParamName = "robot_base_frame_id";
 constexpr const char* kRobotControllerNameParamName =
     "robot_controller_instance";
 constexpr const char* kThrottleRobotStateTopicParamName =
@@ -71,6 +72,9 @@ void WorldBridge::declare_ros_parameters(
       kForceTorqueSensorFrameIDParamName,
       rclcpp::ParameterValue(
           "force_torque_sensor/force_torque_sensor/AtiForceTorqueSensor"));
+  param_interface->declare_parameter(
+      kRobotBaseFrameIDParamName,
+      rclcpp::ParameterValue("robot/robot/base_link"));
   param_interface->declare_parameter(
       kRobotControllerNameParamName,
       rclcpp::ParameterValue("robot_controller"));
@@ -188,6 +192,8 @@ bool WorldBridge::initialize(ROSNodeInterfaces ros_node_interfaces,
   data_->ft_sensor_frame_id_ =
       param_interface->get_parameter(kForceTorqueSensorFrameIDParamName)
           .as_string();
+  data_->robot_base_frame_id_ =
+      param_interface->get_parameter(kRobotBaseFrameIDParamName).as_string();
 
   // Start a thread to publish sceneObject visualization messages whenever a new
   // object arrives
@@ -518,7 +524,8 @@ void WorldBridge::HandleRobotStatus(
     const std::string& part_name = data_->robot_arm_part_name_.value();
     auto it = robot_status.status_map().find(part_name);
     if (it != robot_status.status_map().end()) {
-      PublishJointState(part_name, it->second, time);
+      PublishJointState(part_name, data_->robot_base_frame_id_, it->second,
+                        time);
     } else {
       LOG_EVERY_N(ERROR, 100)
           << "Error: Robot arm part [" << part_name << "] not found!";
@@ -539,12 +546,12 @@ void WorldBridge::HandleRobotStatus(
 }
 
 void WorldBridge::PublishJointState(
-    const std::string& part_name,
+    const std::string& part_name, const std::string& frame_id,
     const intrinsic_proto::icon::PartStatus& part_status,
     const rclcpp::Time& time) {
   sensor_msgs::msg::JointState robot_joint_state_ros;
   robot_joint_state_ros.header.stamp = time;
-  robot_joint_state_ros.header.frame_id = "";
+  robot_joint_state_ros.header.frame_id = frame_id;
 
   for (int i = 0; i < part_status.joint_states_size(); ++i) {
     const auto& joint_state = part_status.joint_states(i);

--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -62,12 +62,11 @@ void WorldBridge::declare_ros_parameters(
                                      rclcpp::ParameterValue(true));
   param_interface->declare_parameter(kEnableForceTorqueTopicParamName,
                                      rclcpp::ParameterValue(true));
-  param_interface->declare_parameter(
-      kRobotJointStateTopicParamName,
-      rclcpp::ParameterValue("/robot_joint_state"));
+  param_interface->declare_parameter(kRobotJointStateTopicParamName,
+                                     rclcpp::ParameterValue("/joint_states"));
   param_interface->declare_parameter(
       kForceTorqueTopicParamName,
-      rclcpp::ParameterValue("/force_torque_sensor"));
+      rclcpp::ParameterValue("/fts_broadcaster/wrench"));
   param_interface->declare_parameter(
       kForceTorqueSensorFrameIDParamName,
       rclcpp::ParameterValue(

--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -45,6 +45,7 @@ constexpr const char* kRobotControllerNameParamName =
     "robot_controller_instance";
 constexpr const char* kThrottleRobotStateTopicParamName =
     "throttle_robot_state_topic";
+constexpr const char* kOverrideJointNamesParamName = "override_joint_names";
 
 ///=============================================================================
 void WorldBridge::declare_ros_parameters(
@@ -79,6 +80,9 @@ void WorldBridge::declare_ros_parameters(
       rclcpp::ParameterValue("robot_controller"));
   param_interface->declare_parameter(kThrottleRobotStateTopicParamName,
                                      rclcpp::ParameterValue(false));
+  param_interface->declare_parameter(
+      kOverrideJointNamesParamName,
+      rclcpp::ParameterValue(std::vector<std::string>{}));
 }
 
 ///=============================================================================
@@ -133,6 +137,10 @@ bool WorldBridge::initialize(ROSNodeInterfaces ros_node_interfaces,
   data_->mesh_url_prefix_ =
       param_interface->get_parameter(kMeshUrlPrefixParamName)
           .get_value<std::string>();
+
+  data_->override_joint_names_ =
+      param_interface->get_parameter(kOverrideJointNamesParamName)
+          .as_string_array();
 
   auto tf_sub_ = data_->world_->CreateTfSubscription(
       [this](const intrinsic_proto::TFMessage& msg) { this->TfCallback(msg); });
@@ -555,6 +563,17 @@ void WorldBridge::PublishJointState(
   for (int i = 0; i < part_status.joint_states_size(); ++i) {
     const auto& joint_state = part_status.joint_states(i);
     std::string joint_name = absl::StrFormat("%s_joint_%d", part_name, i);
+    if (!data_->override_joint_names_.empty()) {
+      if (std::size_t(part_status.joint_states_size()) ==
+          data_->override_joint_names_.size()) {
+        joint_name = data_->override_joint_names_[i];
+      } else {
+        LOG_EVERY_N(ERROR, 100)
+            << "Size of override_joint_names is not equal to "
+               "size of joints from part ["
+            << part_name << "]. Using default joint names!";
+      }
+    }
     robot_joint_state_ros.name.push_back(joint_name);
 
     double pos = joint_state.has_position_sensed()

--- a/flowstate_ros_bridge/src/bridges/world_bridge.hpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.hpp
@@ -102,6 +102,8 @@ class WorldBridge : public BridgeInterface {
     std::optional<std::string> robot_arm_part_name_;
     std::optional<std::string> force_torque_part_name_;
 
+    std::vector<std::string> override_joint_names_;
+
     std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>>
         workcell_markers_pub_;
     std::string tf_prefix_;

--- a/flowstate_ros_bridge/src/bridges/world_bridge.hpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.hpp
@@ -60,6 +60,7 @@ class WorldBridge : public BridgeInterface {
                          const rclcpp::Time& time);
 
   void PublishJointState(const std::string& part_name,
+                         const std::string& frame_id,
                          const intrinsic_proto::icon::PartStatus& part_status,
                          const rclcpp::Time& time);
 
@@ -96,6 +97,7 @@ class WorldBridge : public BridgeInterface {
     bool robot_joint_state_topic_enabled_;
     bool force_torque_topic_enabled_;
     std::string ft_sensor_frame_id_;
+    std::string robot_base_frame_id_;
     // Cached part names to avoid repeated map iteration
     std::optional<std::string> robot_arm_part_name_;
     std::optional<std::string> force_torque_part_name_;

--- a/flowstate_ros_bridge/src/flowstate_ros_bridge_main.cpp
+++ b/flowstate_ros_bridge/src/flowstate_ros_bridge_main.cpp
@@ -100,6 +100,7 @@ int main(int argc, char* argv[]) {
                       s.enable_force_torque_topic());
   params.emplace_back("robot_joint_state_topic", s.robot_joint_state_topic());
   params.emplace_back("force_torque_topic", s.force_torque_topic());
+  params.emplace_back("robot_base_frame_id", s.robot_base_frame_id());
   params.emplace_back("force_torque_sensor_frame_id",
                       s.force_torque_sensor_frame_id());
   params.emplace_back("robot_controller_instance",

--- a/flowstate_ros_bridge/src/flowstate_ros_bridge_main.cpp
+++ b/flowstate_ros_bridge/src/flowstate_ros_bridge_main.cpp
@@ -107,6 +107,10 @@ int main(int argc, char* argv[]) {
                       s.robot_controller_instance());
   params.emplace_back("throttle_robot_state_topic",
                       s.throttle_robot_state_topic());
+  const auto& override_joint_names_proto = s.override_joint_names();
+  std::vector<std::string> override_joint_names(
+      override_joint_names_proto.begin(), override_joint_names_proto.end());
+  params.emplace_back("override_joint_names", override_joint_names);
 
   options.parameter_overrides(params);
 


### PR DESCRIPTION
Changes made:
1. Update default topic names for  `robot_joint_state_topic` and `force_torque_topic` to be consistent with naming convention from `ros2_controls`.
2. Added parameter to define `robot base link frame_id`
3. Add `override_joint_names` parameter to replace default joint names with user-specified ones.