### PR TITLE
Fix package conflicts while building skills using build_container.sh

### DIFF
--- a/resources/Dockerfile.skill
+++ b/resources/Dockerfile.skill
@@ -97,7 +97,7 @@ RUN sed -i '1i #!/usr/bin/env python3' "$SKILL_EXEC_PATH" && chmod +x "$SKILL_EX
 # Setup the runner
 RUN echo '#!/bin/bash' > /run_skill.sh \
     && echo 'set -e' >> /run_skill.sh \
-    && echo 'source /opt/ros/jazzy/setup.bash' >> /run_skill.sh \
+    && echo 'source /opt/ros/${ROS_DISTRO}/setup.bash' >> /run_skill.sh \
     && echo 'source /opt/ros/underlay/install/setup.bash' >> /run_skill.sh \
     && echo 'source /opt/ros/overlay/install/setup.bash' >> /run_skill.sh \
     && echo 'export RMW_IMPLEMENTATION=rmw_zenoh_cpp' >> /run_skill.sh \

--- a/resources/Dockerfile.skill
+++ b/resources/Dockerfile.skill
@@ -78,7 +78,7 @@ RUN apt-get update \
        python3-pip \
        ${DEPENDENCIES} \
     && rm -rf /var/lib/apt/lists/* \
-    && pip3 install --upgrade protobuf grpcio grpcio-status --break-system-packages
+    && pip3 install --upgrade --ignore-installed typing_extensions protobuf grpcio grpcio-status --break-system-packages
 
 COPY --from=overlay /opt/ros/underlay/install /opt/ros/underlay/install
 COPY --from=overlay /opt/ros/overlay/install /opt/ros/overlay/install


### PR DESCRIPTION
This PR fixes package conflicts between `apt` and `pip` package managers when building a skill using `build_container.sh`.

# Issue encountered:

1. Package manager conflicts
```
16.21 Installing collected packages: typing-extensions, protobuf, grpcio, googleapis-common-protos, grpcio-status
16.21   Attempting uninstall: typing-extensions
16.23     Found existing installation: typing_extensions 4.10.0
16.23 ERROR: Cannot uninstall typing_extensions 4.10.0, RECORD file not found. Hint: The package was installed by debian.
------
Dockerfile.skill:75
--------------------
  74 |     # so they exist in this final image.
  75 | >>> RUN apt-get update \
  76 | >>>     && apt-get install -y \
  77 | >>>     ros-${ROS_DISTRO}-rmw-zenoh-cpp \
  78 | >>>     python3-pip \
  79 | >>>     ${DEPENDENCIES} \
  80 | >>>     && rm -rf /var/lib/apt/lists/* \
  81 | >>>     && pip3 install --upgrade protobuf grpcio grpcio-status --break-system-packages
  82 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get update     && apt-get install -y     ros-${ROS_DISTRO}-rmw-zenoh-cpp     python3-pip     ${DEPENDENCIES}     && rm -rf /var/lib/apt/lists/*     && pip3 install --upgrade protobuf grpcio grpcio-status --break-system-packages" did not complete successfully: exit code: 1
```

2. Hardcoded path to `/opt/ros/jazzy/setup.bash`

Received the following error from skills log:
```
/skills/skill_service: line 3: /opt/ros/jazzy/setup.bash: No such file or directory
```

# Fix 

1. Add `--ignore-installed typing_extensions` to fix `typing_extensions` package conflict between pip and apt.

2. Replace jazzy distro with {ROS-DISTRO}