### PR TITLE
Update Flowstate ROS Gz bridge service to be compatible with Gazebo running as Service asset

### DIFF
--- a/flowstate_ros_gz_bridge/flowstate_ros_gz_bridge_config.proto
+++ b/flowstate_ros_gz_bridge/flowstate_ros_gz_bridge_config.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package flowstate;
 
+import "intrinsic/assets/proto/field_metadata.proto";
+import "intrinsic/assets/proto/v1/resolved_dependency.proto";
+
 message RosGzBridgeConfig {
   enum BridgeDirection {
     DIRECTION_UNSPECIFIED = 0;
@@ -41,4 +44,16 @@ message RosGzBridgeConfig {
   }
 
   repeated BridgeConfig bridges = 1;
+}
+
+message RosGzBridgeServiceConfig {
+  RosGzBridgeConfig ros_gz_bridge_config = 1;
+
+  // Dependency on Gazebo simulator asset.
+  // If unset, the bridge will assume that Gazebo is running at
+  // `runtime_context.simulation_server_address`.
+  optional intrinsic_proto.assets.v1.ResolvedDependency gazebo_simulator = 2
+      [(intrinsic_proto.assets.field_metadata).dependency = {
+        requires: "grpc://intrinsic_proto.simulation.v1.GazeboService",
+      }];
 }

--- a/flowstate_ros_gz_bridge/flowstate_ros_gz_bridge_service_default_config.pbtxt
+++ b/flowstate_ros_gz_bridge/flowstate_ros_gz_bridge_service_default_config.pbtxt
@@ -1,13 +1,15 @@
 # proto-file: google/protobuf/any.proto
 # proto-message: Any
-[type.googleapis.com/flowstate.RosGzBridgeConfig] {
-  bridges {
-    ros_topic_name: "/clock"
-    gz_topic_name: "/clock"
-    ros_type_name: "rosgraph_msgs/msg/Clock"
-    gz_type_name: "gz.msgs.Clock"
-    lazy: false
-    direction: GZ_TO_ROS
-    qos_profile: CLOCK
+[type.googleapis.com/flowstate.RosGzBridgeServiceConfig] {
+  ros_gz_bridge_config {
+    bridges {
+      ros_topic_name: "/clock"
+      gz_topic_name: "/clock"
+      ros_type_name: "rosgraph_msgs/msg/Clock"
+      gz_type_name: "gz.msgs.Clock"
+      lazy: false
+      direction: GZ_TO_ROS
+      qos_profile: CLOCK
+    }
   }
 }

--- a/flowstate_ros_gz_bridge/src/flowstate_ros_gz_bridge.cc
+++ b/flowstate_ros_gz_bridge/src/flowstate_ros_gz_bridge.cc
@@ -16,10 +16,12 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <memory>
 
 #include "google/protobuf/util/json_util.h"
 
+#include "intrinsic/assets/proto/v1/resolved_dependency.pb.h"
 #include "intrinsic/resources/proto/runtime_context.pb.h"
 #include "rclcpp/rclcpp.hpp"
 #include "flowstate_ros_gz_bridge_config.pb.h"
@@ -34,10 +36,16 @@ class FlowstateRosGzBridge : public ros_gz_bridge::RosGzBridge {
   using SimConnection = intrinsic::simulation::SimConnection;
   // Constructor
   explicit FlowstateRosGzBridge(
+      std::optional<intrinsic_proto::assets::v1::ResolvedDependency> resolved_deps,
       const std::string& simulation_server_address,
       const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
     : ros_gz_bridge::RosGzBridge(options) {
-      auto res = SimConnection::Create(simulation_server_address);
+      absl::StatusOr<std::shared_ptr<SimConnection>> res;
+      if (resolved_deps.has_value()) {
+        res = SimConnection::CreateFromResolvedDependency(*resolved_deps);
+      } else {
+        res = SimConnection::Create(simulation_server_address);
+      }
       if (res.ok())
       {
         this->sim_conn_ = *res;
@@ -76,25 +84,26 @@ intrinsic_proto::config::RuntimeContext GetRuntimeContext() {
   if (!runtime_context.ParseFromIstream(&runtime_context_file)) {
     // Return default context for running locally
     std::cerr << "Warning: using default RuntimeContext\n";
-    flowstate::RosGzBridgeConfig default_ros_config = MakeTestConfig();
-    runtime_context.mutable_config()->PackFrom(default_ros_config);
+    flowstate::RosGzBridgeServiceConfig default_service_config;
+    *default_service_config.mutable_ros_gz_bridge_config() = MakeTestConfig();
+    runtime_context.mutable_config()->PackFrom(default_service_config);
   }
   return runtime_context;
 }
 
 int main(int , char**) {
   auto runtime_context = GetRuntimeContext();
-  flowstate::RosGzBridgeConfig ros_config;
-  if (!runtime_context.config().UnpackTo(&ros_config)) {
+  flowstate::RosGzBridgeServiceConfig service_config;
+  if (!runtime_context.config().UnpackTo(&service_config)) {
     std::cerr << "Unable to unpack runtime_context\n";
     return EXIT_FAILURE;
   }
 
-  // Parse it to json
+  // Parse the bridge config to json
   std::string json_config;
   google::protobuf::util::JsonPrintOptions options;
   options.preserve_proto_field_names = true;
-  const auto status = google::protobuf::util::MessageToJsonString(ros_config, &json_config, options);
+  const auto status = google::protobuf::util::MessageToJsonString(service_config.ros_gz_bridge_config(), &json_config, options);
   if (status.ok()) {
     // A bit hacky, manually remove the top field to flatten the structure
     // and make it a repeated yaml
@@ -125,8 +134,13 @@ int main(int , char**) {
   // Get ROS arguments
   std::vector<const char *> ros_argv = {"--ros-args", "-p", config_file_param.c_str()};
 
+  std::optional<intrinsic_proto::assets::v1::ResolvedDependency> resolved_deps = std::nullopt;
+  if (service_config.has_gazebo_simulator()) {
+    resolved_deps = service_config.gazebo_simulator();
+  }
+
   rclcpp::init(ros_argv.size(), ros_argv.data());
-  rclcpp::spin(std::make_shared<FlowstateRosGzBridge>(runtime_context.simulation_server_address()));
+  rclcpp::spin(std::make_shared<FlowstateRosGzBridge>(resolved_deps, runtime_context.simulation_server_address()));
   rclcpp::shutdown();
   return EXIT_SUCCESS;
 }

--- a/flowstate_ros_gz_bridge/src/flowstate_ros_gz_bridge.cc
+++ b/flowstate_ros_gz_bridge/src/flowstate_ros_gz_bridge.cc
@@ -30,34 +30,16 @@
 
 #include "sim_connection.h"
 
+using SimConnection = intrinsic::simulation::SimConnection;
 
 class FlowstateRosGzBridge : public ros_gz_bridge::RosGzBridge {
  public:
-  using SimConnection = intrinsic::simulation::SimConnection;
   // Constructor
   explicit FlowstateRosGzBridge(
-      std::optional<intrinsic_proto::assets::v1::ResolvedDependency> resolved_deps,
-      const std::string& simulation_server_address,
+      std::shared_ptr<SimConnection> sim_conn,
       const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
-    : ros_gz_bridge::RosGzBridge(options) {
-      absl::StatusOr<std::shared_ptr<SimConnection>> res;
-      if (resolved_deps.has_value()) {
-        res = SimConnection::CreateFromResolvedDependency(*resolved_deps);
-      } else {
-        res = SimConnection::Create(simulation_server_address);
-      }
-      if (res.ok())
-      {
-        this->sim_conn_ = *res;
-        // Set the gz::transport::Node for the ros gz bridge to the simulation connection node
-        this->gz_node_ = this->sim_conn_->Node();
-      }
-      else
-      {
-        RCLCPP_ERROR(this->get_logger(), "Failed initializing Simulation Connection");
-        // TODO(luca) a make function that returns a pointer instead so we can fail
-        return;
-      }
+    : ros_gz_bridge::RosGzBridge(options), sim_conn_(std::move(sim_conn)) {
+      this->gz_node_ = this->sim_conn_->Node();
     }
  private:
   std::shared_ptr<SimConnection> sim_conn_;
@@ -134,13 +116,27 @@ int main(int , char**) {
   // Get ROS arguments
   std::vector<const char *> ros_argv = {"--ros-args", "-p", config_file_param.c_str()};
 
-  std::optional<intrinsic_proto::assets::v1::ResolvedDependency> resolved_deps = std::nullopt;
+  std::shared_ptr<SimConnection> sim_conn;
   if (service_config.has_gazebo_simulator()) {
-    resolved_deps = service_config.gazebo_simulator();
+    auto res = SimConnection::CreateFromResolvedDependency(service_config.gazebo_simulator());
+    if (!res.ok()) {
+      std::cerr << "Failed initializing SimConnection from resolved dep: "
+                << res.status() << std::endl;
+      return EXIT_FAILURE;
+    }
+    sim_conn = *res;
+  } else {
+    auto res = SimConnection::Create(runtime_context.simulation_server_address());
+    if (!res.ok()) {
+      std::cerr << "Failed initializing SimConnection from simulation server address: "
+                << res.status() << std::endl;
+      return EXIT_FAILURE;
+    }
+    sim_conn = *res;
   }
 
   rclcpp::init(ros_argv.size(), ros_argv.data());
-  rclcpp::spin(std::make_shared<FlowstateRosGzBridge>(resolved_deps, runtime_context.simulation_server_address()));
+  rclcpp::spin(std::make_shared<FlowstateRosGzBridge>(std::move(sim_conn)));
   rclcpp::shutdown();
   return EXIT_SUCCESS;
 }

--- a/flowstate_ros_gz_bridge/src/sim_connection.cc
+++ b/flowstate_ros_gz_bridge/src/sim_connection.cc
@@ -28,13 +28,18 @@
 #include <utility>
 
 #include "absl/cleanup/cleanup.h"
-#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "absl/time/time.h"
 #include "gz/transport/Node.hh"
 #include "gz/transport/NodeOptions.hh"
 #include "gz/transport/TopicUtils.hh"
+#include "intrinsic/assets/dependencies/utils.h"
+#include "intrinsic/connect/cc/grpc/channel.h"
+#include "intrinsic/simulation/gazebo/proto/v1/gazebo_service.grpc.pb.h"
+#include "intrinsic/simulation/gazebo/proto/v1/gazebo_service.pb.h"
+#include "intrinsic/util/status/status_conversion_grpc.h"
 #include "intrinsic/util/status/status_macros.h"
 
 namespace intrinsic {
@@ -111,18 +116,52 @@ absl::StatusOr<std::shared_ptr<SimConnection>> SimConnection::Create(
   INTR_ASSIGN_OR_RETURN(gz::transport::NodeOptions node_opts,
                         DefaultNodeOptions());
 
-  auto sim_connection =
-      std::shared_ptr<SimConnection>(new SimConnection(std::move(node_opts)));
+  return std::shared_ptr<SimConnection>(
+      new SimConnection(std::move(node_opts), sim_ip));
+}
+
+absl::StatusOr<std::shared_ptr<SimConnection>>
+SimConnection::CreateFromResolvedDependency(
+    const intrinsic_proto::assets::v1::ResolvedDependency& resolved_deps,
+    absl::Duration connection_timeout) {
+  // Connect to the Gazebo service hosted by the remote server.
+  ::grpc::ClientContext ctx;
+  INTR_ASSIGN_OR_RETURN(
+      std::shared_ptr<::grpc::Channel> channel,
+      intrinsic::assets::dependencies::Connect(
+          ctx, resolved_deps,
+          /*iface=*/"grpc://intrinsic_proto.simulation.v1.GazeboService"));
+
+  // The address field is only used for error reporting as the channel already
+  // embeds the actual address.
+  INTR_RETURN_IF_ERROR(intrinsic::connect::WaitForChannelConnected(
+      "gazebo", channel, absl::Now() + connection_timeout));
+
+  std::unique_ptr<intrinsic_proto::simulation::v1::GazeboService::Stub>
+      gazebo_service_stub(
+          intrinsic_proto::simulation::v1::GazeboService::NewStub(channel));
+
+  intrinsic_proto::simulation::v1::GetIPRequest request;
+  intrinsic_proto::simulation::v1::GetIPResponse response;
+  INTR_RETURN_IF_ERROR(ToAbslStatus(
+      gazebo_service_stub->GetIPForTransportRelay(&ctx, request, &response)));
+
+  INTR_ASSIGN_OR_RETURN(gz::transport::NodeOptions node_opts,
+                        DefaultNodeOptions());
+
+  return std::shared_ptr<SimConnection>(
+      new SimConnection(std::move(node_opts), response.ip_address()));
+}
+
+SimConnection::SimConnection(gz::transport::NodeOptions node_options,
+                             const std::string& sim_ip)
+    : node_(std::make_shared<gz::transport::Node>(std::move(node_options))) {
   // By default, gz-transport does not support communication of nodes on
   // different local networks, e.g. when the sim connection client and the
   // sim server have different subnets. We need to explicitly tell the
   // gz-tranport node to relay traffic to the specified sim server ip.
-  sim_connection->node_->AddGlobalRelay(sim_ip);
-  return sim_connection;
+  node_->AddGlobalRelay(sim_ip);
 }
-
-SimConnection::SimConnection(gz::transport::NodeOptions node_options)
-    : node_(std::make_shared<gz::transport::Node>(std::move(node_options))) {}
 
 std::shared_ptr<gz::transport::Node> SimConnection::Node() { return node_; }
 

--- a/flowstate_ros_gz_bridge/src/sim_connection.h
+++ b/flowstate_ros_gz_bridge/src/sim_connection.h
@@ -20,7 +20,10 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/time/time.h"
 #include "gz/transport/Node.hh"
+#include "intrinsic/assets/proto/v1/resolved_dependency.pb.h"
+#include "intrinsic/connect/cc/grpc/channel.h"
 
 namespace intrinsic {
 namespace simulation {
@@ -38,12 +41,39 @@ class SimConnection {
   static absl::StatusOr<std::shared_ptr<SimConnection>> Create(
       std::string_view sim_server_address);
 
+  // Create a connection to simulation by querying the GazeboService end-point.
+  // The end-point should be listed in the passed resolved dependencies proto.
+  // Asset sim implementations that use this method should list the following
+  // dependency in their configuration protobuf message definition.
+  //
+  // optional intrinsic_proto.assets.v1.ResolvedDependency gazebo_simulator = 1
+  //     [(intrinsic_proto.assets.field_metadata).dependency = {
+  //       requires: "grpc://intrinsic_proto.simulation.v1.GazeboService",
+  //     }];
+  //
+  // For more details on leveraging service -> service dependencies, see
+  // https://flowstate.intrinsic.ai/docs/assets/asset_dependencies/interacting_with_other_assets/#service---service-dependencies
+  //
+  // If simulation connection creation is unsuccessful, the following status
+  // errors are returned:
+  //   * kNotFound: The listed interfaces in `resolved_deps` does not include
+  //     the GazeboService gRPC interface.
+  //   * kUnavailable/kUnimplemented: The simulation server is not available. A
+  //     simulator Service asset may not be installed in the cluster.
+  static absl::StatusOr<std::shared_ptr<SimConnection>>
+  CreateFromResolvedDependency(
+      const intrinsic_proto::assets::v1::ResolvedDependency& resolved_deps,
+      absl::Duration connection_timeout =
+          intrinsic::connect::kGrpcClientConnectDefaultTimeout);
+
   // Get a shared_ptr to the transport node that manages pub/sub connections
   // to simulation.
   std::shared_ptr<gz::transport::Node> Node();
 
  private:
-  explicit SimConnection(gz::transport::NodeOptions node_options);
+  explicit SimConnection(gz::transport::NodeOptions node_options,
+                         const std::string& sim_ip);
+
   // TODO(luca) changed from upstream where it was not wrapped in a shared_ptr
   // ros_gz_bridge required it to be a shared_ptr
   std::shared_ptr<gz::transport::Node> node_;

--- a/intrinsic_sdk_cmake/cmake/fetch_sdk.cmake
+++ b/intrinsic_sdk_cmake/cmake/fetch_sdk.cmake
@@ -1,23 +1,34 @@
 # Fetch the sdk and make it available for use locally.
 
-set(SDK_VERSION_JSON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_version.json")
-file(READ "${SDK_VERSION_JSON_FILE}" sdk_version_json)
-string(JSON sdk_version GET ${sdk_version_json} "sdk_version")
-string(JSON sdk_checksum GET ${sdk_version_json} "sdk_checksum")
-message(STATUS "intrinsic-ai/sdk version: ${sdk_version} ${sdk_checksum}")
+set(sdk_version "0.dev1")
+
+#set(SDK_VERSION_JSON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_version.json")
+#file(READ "${SDK_VERSION_JSON_FILE}" sdk_version_json)
+#string(JSON sdk_version GET ${sdk_version_json} "sdk_version")
+#string(JSON sdk_checksum GET ${sdk_version_json} "sdk_checksum")
+#message(STATUS "intrinsic-ai/sdk version: ${sdk_version} ${sdk_checksum}")
 
 include(FetchContent)
 # Fetch the intrinsic sdk source code during configure stage.
+#FetchContent_Declare(
+#  intrinsic_sdk
+#  URL https://github.com/intrinsic-ai/sdk/archive/refs/tags/${sdk_version}.tar.gz
+#  URL_HASH ${sdk_checksum}
+#  DOWNLOAD_EXTRACT_TIMESTAMP FALSE
+#  PATCH_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/apply_patch.sh
+#    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/001_zenoh_helpers_cc_no_runfiles.patch
+#)
+
+# Override with local path
 FetchContent_Declare(
-  intrinsic_sdk
-  URL https://github.com/intrinsic-ai/sdk/archive/refs/tags/${sdk_version}.tar.gz
-  URL_HASH ${sdk_checksum}
-  DOWNLOAD_EXTRACT_TIMESTAMP FALSE
-  PATCH_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/apply_patch.sh
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/001_zenoh_helpers_cc_no_runfiles.patch
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/002_gcc13_publisher_noexcept.patch
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/003_icon_strerror_glibc2_39.patch
+    intrinsic_sdk
+    SOURCE_DIR "/usr/local/google/home/shameek/sdk"
+    PATCH_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/apply_patch.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/001_zenoh_helpers_cc_no_runfiles.patch
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/002_gcc13_publisher_noexcept.patch
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/003_icon_strerror_glibc2_39.patch
 )
+
 FetchContent_GetProperties(intrinsic_sdk)
 if(NOT intrinsic_sdk_POPULATED)
   # Fetch the content using previously declared details


### PR DESCRIPTION
Updates the Flowstate ROS Gz bridge to take an optional service dependency on `GazeboService`, which is hosted by the [Gazebo simulator Service asset](https://github.com/intrinsic-ai/insrc/blob/a03cece6010a4bcb01242e9f3fc7771bd52efc54/google3/intrinsic/simulation/gazebo/asset/gazebo_simulator_manifest.textproto#L19).

Also updates the `SimConnection` class to be constructed from a `ResolvedDependency` proto, which is populated at runtime by the asset deployment service (mirrors [the update to the internal namesake class](https://github.com/intrinsic-ai/insrc/pull/46539/changes#diff-6a963c4ba4f891eb01896cb0bc82df1343ee8ed298c9d93799d4207a1b0271d3)).

Maintains backwards compatibility with solutions that are running Gazebo at `runtime_context.simulation_server_address`.

## Testing

This change adds a dependency on `intrinsic/simulation/gazebo/proto/v1/gazebo_service.proto`, which is **not yet available in the prod SDK**.

To test this change, first follow the instructions in [go/intrinsic-dev-sdk-ros](http://goto.google.com/intrinsic-dev-sdk-ros) to build `intrinsic_sdk_cmake` from **the dev SDK on [insrc:shameek/dns_sdk_for_ros_gz](https://github.com/intrinsic-ai/insrc/tree/shameek/dns_sdk_for_ros_gz)** (includes go/inpr/46539). (Note that `intrinsic_sdk_cmake` currently does not build against the Dev SDK built at HEAD due to changes in Zenoh dependencies go/inpr/42565. The `shameek/dns_sdk_for_ros_gz` branch cherry-picked go/inpr/46539 onto `intrinsic.platform.20260427.RC20` to circumvent the Zenoh-related build issues.)

Then build the service with
```
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release   -DBUILD_TESTING=OFF  --event-handlers=console_direct+ --merge-install --packages-select flowstate_ros_gz_bridge
```

Next, run `build_container.sh` with 
```
./src/sdk-ros/scripts/build_container.sh --service_package flowstate_ros_gz_bridge --service_name flowstate_ros_gz_bridge_service --dockerfile src/patches/resources/Dockerfile.service.local
```
which uses a modified dockerfile for building services from local workspace build artifacts ([go/intrinsic-dev-sdk-ros#heading=h.d82a49qk6glg](http://goto.google.com/intrinsic-dev-sdk-ros#heading=h.d82a49qk6glg)).

Then, build the service bundle.tar file with
```
./src/sdk-ros/scripts/build_bundle.sh \
  --service_package flowstate_ros_gz_bridge \
  --service_name flowstate_ros_gz_bridge_service \
  --manifest_path src/sdk-ros/flowstate_ros_gz_bridge/flowstate_ros_gz_bridge_service.manifest.textproto \
  --default_config src/sdk-ros/flowstate_ros_gz_bridge/flowstate_ros_gz_bridge_service_default_config.pbtxt
```

Then follow the instructions in [flowstate_ros_gz_bridge/README.md](https://github.com/intrinsic-ai/sdk-ros/blob/shameek/update_ros_gz/flowstate_ros_gz_bridge/README.md) to deploy the bridge service.

In Flowstate, after instantiating the `FlowstateRosGzBridgeService`, 
- select the instance and open the `Config` tab on the left, then
- select the Gazebo simulator asset instance to connect to,
- click `Apply` at the bottom.

Test for communication as instructed in https://github.com/intrinsic-ai/sdk-ros/blob/main/flowstate_ros_gz_bridge/README.md#instantiate-the-service
