### PR TITLE
Version bump to SDK v1.31.20260427 

### DIFF
--- a/intrinsic_sdk_cmake/cmake/fetch_sdk.cmake
+++ b/intrinsic_sdk_cmake/cmake/fetch_sdk.cmake
@@ -16,6 +16,7 @@ FetchContent_Declare(
   PATCH_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/apply_patch.sh
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/001_zenoh_helpers_cc_no_runfiles.patch
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/002_gcc13_publisher_noexcept.patch
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdk_patches/003_icon_strerror_glibc2_39.patch
 )
 FetchContent_GetProperties(intrinsic_sdk)
 if(NOT intrinsic_sdk_POPULATED)

--- a/intrinsic_sdk_cmake/cmake/sdk.cmake
+++ b/intrinsic_sdk_cmake/cmake/sdk.cmake
@@ -72,6 +72,9 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
+    absl::failure_signal_handler
+    absl::symbolize
+    absl::stacktrace
     absl::base
     absl::flags_parse
     absl::flags_usage

--- a/intrinsic_sdk_cmake/cmake/sdk_patches/001_zenoh_helpers_cc_no_runfiles.patch
+++ b/intrinsic_sdk_cmake/cmake/sdk_patches/001_zenoh_helpers_cc_no_runfiles.patch
@@ -1,5 +1,5 @@
---- a/intrinsic/platform/pubsub/zenoh_util/zenoh_helpers.cc	2026-03-17 17:56:14.511113379 +0000
-+++ b/intrinsic/platform/pubsub/zenoh_util/zenoh_helpers.cc	2026-03-17 18:20:43.751982100 +0000
+--- a/intrinsic/platform/pubsub/zenoh_util/zenoh_helpers.cc	2026-05-06 20:23:45.229207000 +0000
++++ b/intrinsic/platform/pubsub/zenoh_util/zenoh_helpers.cc	2026-05-07 07:20:25.229618669 +0000
 @@ -2,7 +2,9 @@
  
  #include "intrinsic/platform/pubsub/zenoh_util/zenoh_helpers.h"
@@ -25,7 +25,7 @@
  bool RunningUnderTest() {
    return (getenv("TEST_TMPDIR") != nullptr) ||
           (getenv("PORTSERVER_ADDRESS") != nullptr);
-@@ -27,26 +26,32 @@
+@@ -27,25 +26,32 @@
    return getenv("KUBERNETES_SERVICE_HOST") != nullptr;
  }
  
@@ -39,7 +39,6 @@
 +
  std::string GetZenohRunfilesPath(absl::string_view file_path) {
 -  std::string error;
--  std::string path = std::string(file_path);
 -  std::string repository = BAZEL_CURRENT_REPOSITORY;
 -  std::string apparentRepoName = "";
 -  std::unique_ptr<Runfiles> runfiles;
@@ -49,6 +48,14 @@
 -    runfiles.reset(Runfiles::Create(repository, &error));
 -  } else {
 -    runfiles.reset(Runfiles::Create(program_invocation_name, &error));
+-  }
+-
+-  if (RunningInKubernetes() || RunningUnderTest()) {
+-    apparentRepoName = "ai_intrinsic_sdks";
+-  } else {
+-    apparentRepoName = repository;
+-  }
+-  return runfiles->Rlocation(absl::StrCat(apparentRepoName, "/", file_path));
 +  // Patched by intrinsic-dev/intrinsic_sdk_ros.git to work in a CMake context.
 +  // TODO(wjwwood): consider using ament_index to make this code relocatable.
 +  std::array<std::filesystem::path, 2> prefix_paths = {
@@ -62,14 +69,8 @@
 +    if (std::filesystem::exists(possible_path)) {
 +      return possible_path.string();
 +    }
-   }
- 
--  if (RunningInKubernetes() || RunningUnderTest()) {
--    apparentRepoName = "ai_intrinsic_sdks";
--  } else {
--    apparentRepoName = repository;
--  }
--  return runfiles->Rlocation(absl::StrCat(apparentRepoName, "/", file_path));
++   }
++
 +  // Return the original file_path if nothing better was found.
 +  return std::string(file_path);
  }

--- a/intrinsic_sdk_cmake/cmake/sdk_patches/003_icon_strerror_glibc2_39.patch
+++ b/intrinsic_sdk_cmake/cmake/sdk_patches/003_icon_strerror_glibc2_39.patch
@@ -1,0 +1,23 @@
+--- a/intrinsic/icon/utils/strerror.h	2026-05-11 17:52:10.269743474 +0000
++++ b/intrinsic/icon/utils/strerror.h	2026-05-11 17:54:08.772844870 +0000
+@@ -4,7 +4,7 @@
+ #define INTRINSIC_ICON_UTILS_STRERROR_H_
+
+ #include <cstddef>
+-#include <cstdio>
++#include <cstring>
+
+ #include "intrinsic/icon/utils/fixed_str_cat.h"
+ #include "intrinsic/icon/utils/fixed_string.h"
+@@ -22,8 +22,9 @@
+ // https://www.club.cc.cmu.edu/~cmccabe/blog_strerror.html.
+ template <std::size_t N = 128>
+ icon::FixedString<N> StrError(const int err) {
+-  if (err >= 0 && err < ::sys_nerr) {
+-    return icon::FixedStrCat<N>(::sys_errlist[err]);
++  const char* desc = strerrordesc_np(err);
++  if (desc != nullptr) {
++    return icon::FixedStrCat<N>(desc);
+   }
+   return icon::FixedStrCat<N>("Unknown error ", err);
+ }

--- a/intrinsic_sdk_cmake/cmake/sdk_version.json
+++ b/intrinsic_sdk_cmake/cmake/sdk_version.json
@@ -1,4 +1,4 @@
 {
-	"sdk_version": "v1.28.20260223",
-	"sdk_checksum": "SHA256=41a9ecaa0b8ee3ef22dec921b9c048520e884629a5caed1e961ff7f6c736992f"
+	"sdk_version": "v1.31.20260427",
+	"sdk_checksum": "SHA256=a9bfa0a40dc8d79b7e33594e2a0a94e406747da0c2b7e3d62e926163e0848034"
 }


### PR DESCRIPTION
- Updated intrinsic_sdk_cmake/cmake/sdk_patches/001_zenoh_helpers_cc_no_runfiles.patch
- Added intrinsic_sdk_cmake/cmake/sdk_patches/003_icon_strerror_glibc2_39.patch
    - intrinsic/icon/utils/strerror.h is using the `sys_errlist` and `sys_nerr` globals from stdio.h which were removed in glibc2.32.
- Exported additional `absl` components from `intrinsic_sdk_cmake`