### PR TITLE
Adding support for ROS_DISTRO inside intrinsic_sdk_cmake

### DIFF
--- a/.github/workflows/build_container_images.yaml
+++ b/.github/workflows/build_container_images.yaml
@@ -110,6 +110,7 @@ jobs:
           build-args: |
             REPOSITORY=localhost:5000
             TAG=temp
+            BASE_IMAGE_TAG=temp
           tags: |
             localhost:5000/intrinsic_sdk_cmake:temp
       - name: Build intrinsic_sdk_cmake_run Docker Image
@@ -123,6 +124,8 @@ jobs:
           build-args: |
             REPOSITORY=localhost:5000
             TAG=temp
+            BUILD_IMAGE_TAG=temp
+            BASE_IMAGE_TAG=temp
           tags: |
             localhost:5000/intrinsic_sdk_cmake_run:temp
 

--- a/.github/workflows/build_container_images.yaml
+++ b/.github/workflows/build_container_images.yaml
@@ -124,7 +124,6 @@ jobs:
           build-args: |
             REPOSITORY=localhost:5000
             TAG=temp
-            BUILD_IMAGE_TAG=temp
             BASE_IMAGE_TAG=temp
           tags: |
             localhost:5000/intrinsic_sdk_cmake_run:temp

--- a/.github/workflows/deploy_container_images.yaml
+++ b/.github/workflows/deploy_container_images.yaml
@@ -75,31 +75,55 @@ jobs:
         run: |
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake_base:temp \
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:${{ env.INTRINSIC_AI_SDK_VERSION }}
+          docker image tag \
+            localhost:5000/intrinsic_sdk_cmake_base:temp \
             ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake_base:temp \
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:latest
+          docker image tag \
+            localhost:5000/intrinsic_sdk_cmake_base:temp \
             ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:latest-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:${{ env.INTRINSIC_AI_SDK_VERSION }}
           docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:latest
           docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:latest-${{ env.ROS_DISTRO }}
       - name: Tag intrinsic_sdk_cmake Container Image
         run: |
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake:temp \
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:${{ env.INTRINSIC_AI_SDK_VERSION }}
+          docker image tag \
+            localhost:5000/intrinsic_sdk_cmake:temp \
             ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake:temp \
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:latest
+          docker image tag \
+            localhost:5000/intrinsic_sdk_cmake:temp \
             ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:latest-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:${{ env.INTRINSIC_AI_SDK_VERSION }}
           docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:latest
           docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:latest-${{ env.ROS_DISTRO }}
       - name: Tag intrinsic_sdk_cmake_run Container Image
         run: |
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake_run:temp \
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:${{ env.INTRINSIC_AI_SDK_VERSION }}
+          docker image tag \
+            localhost:5000/intrinsic_sdk_cmake_run:temp \
             ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake_run:temp \
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:latest
+          docker image tag \
+            localhost:5000/intrinsic_sdk_cmake_run:temp \
             ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:latest-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:${{ env.INTRINSIC_AI_SDK_VERSION }}
           docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:latest
           docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:latest-${{ env.ROS_DISTRO }}
 
       # TODO(wjwwood): use actions/attest-build-provenance to write the attestation info to the

--- a/.github/workflows/deploy_container_images.yaml
+++ b/.github/workflows/deploy_container_images.yaml
@@ -12,6 +12,8 @@ concurrency:
   # Cancel all but the latest run of this workflow, because only the latest run of this
   # workflow matters, as it overwrites the latest tag of the container images.
   cancel-in-progress: true
+env:
+  ROS_DISTRO: jazzy
 jobs:
   build-test:
     uses: ./.github/workflows/test_container_images.yaml
@@ -73,32 +75,32 @@ jobs:
         run: |
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake_base:temp \
-            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:${{ env.INTRINSIC_AI_SDK_VERSION }}
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake_base:temp \
-            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:latest
-          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:${{ env.INTRINSIC_AI_SDK_VERSION }}
-          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:latest
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:latest-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_base:latest-${{ env.ROS_DISTRO }}
       - name: Tag intrinsic_sdk_cmake Container Image
         run: |
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake:temp \
-            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:${{ env.INTRINSIC_AI_SDK_VERSION }}
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake:temp \
-            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:latest
-          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:${{ env.INTRINSIC_AI_SDK_VERSION }}
-          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:latest
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:latest-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake:latest-${{ env.ROS_DISTRO }}
       - name: Tag intrinsic_sdk_cmake_run Container Image
         run: |
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake_run:temp \
-            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:${{ env.INTRINSIC_AI_SDK_VERSION }}
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
           docker image tag \
             localhost:5000/intrinsic_sdk_cmake_run:temp \
-            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:latest
-          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:${{ env.INTRINSIC_AI_SDK_VERSION }}
-          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:latest
+            ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:latest-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:${{ env.INTRINSIC_AI_SDK_VERSION }}-${{ env.ROS_DISTRO }}
+          docker push ghcr.io/intrinsic-ai/intrinsic_sdk_cmake_run:latest-${{ env.ROS_DISTRO }}
 
       # TODO(wjwwood): use actions/attest-build-provenance to write the attestation info to the
       #   container registry, see:

--- a/intrinsic_sdk_cmake/docker_images/README.md
+++ b/intrinsic_sdk_cmake/docker_images/README.md
@@ -113,7 +113,7 @@ $ podman build \
   .
 ```
 
-Note that if you want to build it off of a different tag of the base image, you'll need to change the `TAG` argument.
+Note that if you want to build it off of a different version tag of the base image, you can change the `TAG` argument (e.g. `--build-arg TAG=temp`), which will still append the ROS distro automatically. Alternatively, you can completely override the base tag format by passing `BASE_IMAGE_TAG` (e.g. `--build-arg BASE_IMAGE_TAG=my-custom-tag`).
 
 #### (Optional) push to local container registry
 

--- a/intrinsic_sdk_cmake/docker_images/README.md
+++ b/intrinsic_sdk_cmake/docker_images/README.md
@@ -50,6 +50,14 @@ This doesn't happen with the base image since it doesn't depend on another of ou
 
 ---
 
+Additionally, the images support selecting the ROS distro via the `ROS_DISTRO` build argument. This defaults to `jazzy`. For example:
+
+```
+--build-arg ROS_DISTRO=jazzy
+```
+
+---
+
 Additionally, you should always build the images from the root of the repository, so that the docker images can access the local files from a consistent location.
 
 ### Build the base image

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake.Dockerfile
@@ -4,7 +4,8 @@
 ARG REPOSITORY=ghcr.io/intrinsic-ai
 ARG TAG=latest
 ARG ROS_DISTRO=jazzy
-FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${TAG}-${ROS_DISTRO} AS base
+ARG BASE_IMAGE_TAG=${TAG}-${ROS_DISTRO}
+FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${BASE_IMAGE_TAG} AS base
 
 # source stage: base + source added
 FROM base AS source

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake.Dockerfile
@@ -4,10 +4,16 @@
 ARG REPOSITORY=ghcr.io/intrinsic-ai
 ARG TAG=latest
 ARG ROS_DISTRO=jazzy
-FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${TAG} AS base
+FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${TAG}-${ROS_DISTRO} AS base
 
 # source stage: base + source added
 FROM base AS source
+
+ARG ROS_DISTRO
+RUN if [ ! -f "/opt/ros/${ROS_DISTRO}/setup.sh" ]; then \
+        echo "Error: ROS_DISTRO=${ROS_DISTRO} mismatch with base image. Could not find /opt/ros/${ROS_DISTRO}/setup.sh" >&2 \
+        && exit 1; \
+    fi
 
 ADD ./ /opt/intrinsic/intrinsic_sdk_cmake/src/intrinsic_sdk_ros
 

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake.Dockerfile
@@ -3,6 +3,7 @@
 
 ARG REPOSITORY=ghcr.io/intrinsic-ai
 ARG TAG=latest
+ARG ROS_DISTRO=jazzy
 FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${TAG} AS base
 
 # source stage: base + source added
@@ -19,6 +20,8 @@ RUN cd /opt/intrinsic/intrinsic_sdk_cmake/src/intrinsic_sdk_ros \
 # build_export stage: source + rosdep install build_export depends
 FROM source AS build_export
 
+ARG ROS_DISTRO
+
 # Setup rosdep
 RUN \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -33,7 +36,7 @@ RUN \
 # Bootstrap rosdep
 RUN set -x \
     && rosdep init \
-    && rosdep update --rosdistro jazzy
+    && rosdep update --rosdistro ${ROS_DISTRO}
 
 # Install exec-like dependencies for the packages in intrinsic_sdk_cmake and
 # save them for re-install in a later stage.
@@ -43,7 +46,7 @@ RUN set -x \
 RUN \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    . /opt/ros/jazzy/setup.sh \
+    . /opt/ros/${ROS_DISTRO}/setup.sh \
     && set -x \
     && rm -f /etc/apt/apt.conf.d/docker-clean \
     && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache \
@@ -51,7 +54,7 @@ RUN \
     && echo "python3-absl-py:" > /etc/ros/rosdep/custom.yaml \
     && echo "  ubuntu: [python3-absl]" >> /etc/ros/rosdep/custom.yaml \
     && echo "yaml file:///etc/ros/rosdep/custom.yaml" > /etc/ros/rosdep/sources.list.d/50-custom.list \
-    && rosdep update --rosdistro jazzy \
+    && rosdep update --rosdistro ${ROS_DISTRO} \
     && cd /opt/intrinsic/intrinsic_sdk_cmake \
     && touch src/intrinsic_sdk_ros/intrinsic_sdk/COLCON_IGNORE \
     && touch src/intrinsic_sdk_ros/intrinsic_sdk_ros/COLCON_IGNORE \
@@ -72,6 +75,8 @@ RUN \
 
 # build stage: build_export + rosdep install all depends + packages up to intrinsic_sdk_cmake built
 FROM build_export AS build
+
+ARG ROS_DISTRO
 
 # Install other development tools.
 RUN \
@@ -104,12 +109,12 @@ RUN set -x \
 RUN \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    . /opt/ros/jazzy/setup.sh \
+    . /opt/ros/${ROS_DISTRO}/setup.sh \
     && set -x \
     && rm -f /etc/apt/apt.conf.d/docker-clean \
     && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache \
     && apt-get update \
-    && rosdep update --rosdistro jazzy \
+    && rosdep update --rosdistro ${ROS_DISTRO} \
     && cd /opt/intrinsic/intrinsic_sdk_cmake \
     && touch src/intrinsic_sdk_ros/intrinsic_sdk/COLCON_IGNORE \
     && touch src/intrinsic_sdk_ros/intrinsic_sdk_ros/COLCON_IGNORE \
@@ -121,7 +126,7 @@ RUN \
 # Build intrinsic_sdk_cmake and all of its dependencies.
 RUN \
     --mount=type=cache,target=/ccache/ \
-    . /opt/ros/jazzy/setup.sh \
+    . /opt/ros/${ROS_DISTRO}/setup.sh \
     && set -x \
     && export CCACHE_DIR=/ccache \
     && export PATH="/usr/lib/ccache:$PATH" \
@@ -136,6 +141,8 @@ RUN \
 
 # result stage: base + copy install artifacts + re-installed build_export depends + dev tools
 FROM base AS result
+
+ARG ROS_DISTRO
 
 # Get the installed artifacts from the build stage.
 COPY --from=build \
@@ -183,7 +190,7 @@ RUN \
 # Bootstrap rosdep
 RUN set -x \
     && rosdep init \
-    && rosdep update --rosdistro jazzy
+    && rosdep update --rosdistro ${ROS_DISTRO}
 
 # Setup colcon mixin and metadata.
 RUN set -x \

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
@@ -2,9 +2,10 @@
 # It needs to be built from the root of the intrinsic_sdk_ros repository.
 
 ARG ROS_DISTRO=jazzy
+ARG BASE_IMAGE=ghcr.io/sloretz/ros:jazzy-ros-core-2025-06-08
 
-# base stage: ghcr.io/sloretz/ros:${ROS_DISTRO}-ros-core + configs + rmw_zenoh
-FROM ghcr.io/sloretz/ros:${ROS_DISTRO}-ros-core-2025-06-08 AS base
+# base stage: BASE_IMAGE + configs + rmw_zenoh
+FROM ${BASE_IMAGE} AS base
 # TODO(wjwwood): this is based on the ROS image because we still use
 #   ament_cmake, we should move away from that and either vendor ament_cmake or
 #   avoid it entirely.

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
@@ -2,7 +2,7 @@
 # It needs to be built from the root of the intrinsic_sdk_ros repository.
 
 ARG ROS_DISTRO=jazzy
-ARG BASE_IMAGE=ghcr.io/sloretz/ros:jazzy-ros-core-2025-06-08
+ARG BASE_IMAGE=ghcr.io/sloretz/ros:${ROS_DISTRO}-ros-core-2025-06-08
 
 # base stage: BASE_IMAGE + configs + rmw_zenoh
 FROM ${BASE_IMAGE} AS base

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_base.Dockerfile
@@ -1,8 +1,10 @@
 # This Dockerfile provides only the source code for intrinsic_sdk_cmake.
 # It needs to be built from the root of the intrinsic_sdk_ros repository.
 
-# base stage: ghcr.io/sloretz/ros:jazzy-ros-core + configs + rmw_zenoh
-FROM ghcr.io/sloretz/ros:jazzy-ros-core-2025-06-08 AS base
+ARG ROS_DISTRO=jazzy
+
+# base stage: ghcr.io/sloretz/ros:${ROS_DISTRO}-ros-core + configs + rmw_zenoh
+FROM ghcr.io/sloretz/ros:${ROS_DISTRO}-ros-core-2025-06-08 AS base
 # TODO(wjwwood): this is based on the ROS image because we still use
 #   ament_cmake, we should move away from that and either vendor ament_cmake or
 #   avoid it entirely.
@@ -19,6 +21,7 @@ WORKDIR /opt/intrinsic
 ENV ROS_HOME=/tmp
 
 # Install rmw_zenoh_cpp and set it as the default RMW implementation.
+ARG ROS_DISTRO
 RUN \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -27,7 +30,7 @@ RUN \
     && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache \
     && apt-get update \
     && apt-get dist-upgrade -y \
-    && apt-get install -y --no-install-recommends ros-jazzy-rmw-zenoh-cpp
+    && apt-get install -y --no-install-recommends ros-${ROS_DISTRO}-rmw-zenoh-cpp
 ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
 RUN set -x \
     && sed --in-place \

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_run.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_run.Dockerfile
@@ -1,9 +1,11 @@
 ARG REPOSITORY=ghcr.io/intrinsic-ai
 ARG TAG=latest
 ARG ROS_DISTRO=jazzy
-FROM ${REPOSITORY}/intrinsic_sdk_cmake:${TAG}-${ROS_DISTRO} as build_image
+ARG BUILD_IMAGE_TAG=${TAG}-${ROS_DISTRO}
+ARG BASE_IMAGE_TAG=${TAG}-${ROS_DISTRO}
+FROM ${REPOSITORY}/intrinsic_sdk_cmake:${BUILD_IMAGE_TAG} as build_image
 
-FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${TAG}-${ROS_DISTRO} as result
+FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${BASE_IMAGE_TAG} as result
 
 # Get the installed artifacts from the build stage.
 COPY --from=build_image \

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_run.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_run.Dockerfile
@@ -1,8 +1,9 @@
 ARG REPOSITORY=ghcr.io/intrinsic-ai
 ARG TAG=latest
-FROM ${REPOSITORY}/intrinsic_sdk_cmake:${TAG} as build_image
+ARG ROS_DISTRO=jazzy
+FROM ${REPOSITORY}/intrinsic_sdk_cmake:${TAG}-${ROS_DISTRO} as build_image
 
-FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${TAG} as result
+FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${TAG}-${ROS_DISTRO} as result
 
 # Get the installed artifacts from the build stage.
 COPY --from=build_image \

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_run.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake_run.Dockerfile
@@ -1,9 +1,8 @@
 ARG REPOSITORY=ghcr.io/intrinsic-ai
 ARG TAG=latest
 ARG ROS_DISTRO=jazzy
-ARG BUILD_IMAGE_TAG=${TAG}-${ROS_DISTRO}
 ARG BASE_IMAGE_TAG=${TAG}-${ROS_DISTRO}
-FROM ${REPOSITORY}/intrinsic_sdk_cmake:${BUILD_IMAGE_TAG} as build_image
+FROM ${REPOSITORY}/intrinsic_sdk_cmake:${BASE_IMAGE_TAG} as build_image
 
 FROM ${REPOSITORY}/intrinsic_sdk_cmake_base:${BASE_IMAGE_TAG} as result
 


### PR DESCRIPTION
This PR adds support for the `ROS_DISTRO` build argument in the standard `intrinsic_sdk_cmake` Dockerfiles, enabling parameterization of the ROS distribution (defaulting to `jazzy`). This matches the pattern implemented in `intrinsic_sdk_bundle_library_py`.