### PR TITLE
Bump SDK to v1.31.20260427.1

### DIFF
--- a/intrinsic_sdk_bundle_library_py/resource/sdk_version.json
+++ b/intrinsic_sdk_bundle_library_py/resource/sdk_version.json
@@ -1,4 +1,4 @@
 {
-	"sdk_version": "v1.31.20260427",
-	"sdk_checksum": "SHA256=a9bfa0a40dc8d79b7e33594e2a0a94e406747da0c2b7e3d62e926163e0848034"
+	"sdk_version": "v1.31.20260427.1",
+	"sdk_checksum": "SHA256=c9d79c0a37e776c1631217aa8ed65a13b1063301fea4aa75e22861c2a6074496"
 }


### PR DESCRIPTION
#### Changes
- Minor SDK version bump to `v1.31.20260427.1` release.
- Fixes issue with `inbuild` getting pulled by `intrinsic_sdk_build bundle` script.