### PR TITLE
Add `colcon intrinsic_bundle` verb extension for building and bundling ROS skills/services

### DIFF
--- a/intrinsic_sdk_bundle_library_py/README.md
+++ b/intrinsic_sdk_bundle_library_py/README.md
@@ -1,0 +1,70 @@
+# Intrinsic SDK Bundle Library (Python)
+
+This package provides Python utilities, a CLI tool, and a `colcon` verb extension to simplify building container images and Intrinsic SDK bundles for custom ROS skills and services.
+
+---
+
+## Installation & Setup
+
+1. Build the library package in your ROS 2 workspace:
+   ```bash
+   colcon build --packages-select intrinsic_sdk_bundle_library_py
+   ```
+2. Source your workspace to register the entry points and register the `colcon` extension:
+   ```bash
+   source install/setup.bash
+   ```
+
+---
+
+## Usage Case 1: Colcon Extension (Recommended)
+
+The `colcon bundle` command automatically scans your workspace, discovers packages containing manifests (`*.manifest.textproto`), determines package types, and handles both building and bundling in a single command.
+
+### Run Bundling
+To build and bundle a specific package:
+```bash
+colcon bundle --packages-select <your_package_name>
+```
+
+### Options
+* `--images-dir <path>`: Directory to save generated container images and bundles (default: `./images`).
+* `--ros-distro <distro>`: The target ROS distro (default: `jazzy`).
+* `--no-cache`: Do not use cache when building container images.
+* `--builder-name <name>`: Custom Docker buildx builder name.
+
+---
+
+## Usage Case 2: Command Line CLI Tool (`intrinsic_sdk_build`)
+
+For finer-grained control or non-colcon environments, you can invoke the packaging steps manually using the direct CLI script.
+
+### 1. Build the Container Image
+Creates a compressed container image from the package source:
+```bash
+intrinsic_sdk_build container \
+  --skill_name <skill_name> \
+  --skill_package <package_name> \
+  --skill_type <cpp|python>
+```
+*Outputs: `./images/<skill_name>/<skill_name>.tar`*
+
+### 2. Build the Bundle
+Bundles the container image along with its manifest using the `inbuild` compiler:
+```bash
+intrinsic_sdk_build bundle \
+  --skill_name <skill_name> \
+  --skill_package <package_name> \
+  --manifest_path <path_to_manifest>
+```
+*Outputs: `./images/<skill_name>/<skill_name>.bundle.tar`*
+
+---
+
+## Architecture & Configuration
+
+### `inbuild` Resolution
+The package requires the `inbuild` binary to build bundles. It resolves `inbuild` using the following order:
+1. **Host PATH**: Checks the host system's `PATH` for `inbuild` (e.g., using `shutil.which`).
+2. **GitHub Releases Fallback**: If not found on the host, it downloads the correct architecture release binary from the GitHub repository (`https://github.com/intrinsic-ai/sdk`).
+3. **Tag Mapping**: Includes an internal version mapper to translate local/CI SDK development tags to valid patch releases on GitHub containing pre-compiled binaries (e.g., `v1.31.20260427` mapping to `v1.31.20260427.1`).

--- a/intrinsic_sdk_bundle_library_py/README.md
+++ b/intrinsic_sdk_bundle_library_py/README.md
@@ -19,12 +19,12 @@ This package provides Python utilities, a CLI tool, and a `colcon` verb extensio
 
 ## Usage Case 1: Colcon Extension (Recommended)
 
-The `colcon bundle` command automatically scans your workspace, discovers packages containing manifests (`*.manifest.textproto`), determines package types, and handles both building and bundling in a single command.
+The `colcon intrinsic_bundle` command automatically scans your workspace, discovers packages containing manifests (`*.manifest.textproto`), determines package types, and handles both building and bundling in a single command.
 
 ### Run Bundling
 To build and bundle a specific package:
 ```bash
-colcon bundle --packages-select <your_package_name>
+colcon intrinsic_bundle --packages-select <your_package_name>
 ```
 
 ### Options

--- a/intrinsic_sdk_bundle_library_py/README.md
+++ b/intrinsic_sdk_bundle_library_py/README.md
@@ -28,7 +28,7 @@ colcon bundle --packages-select <your_package_name>
 ```
 
 ### Options
-* `--images-dir <path>`: Directory to save generated container images and bundles (default: `./images`).
+* `--bundle-dir <path>`: Directory to save generated container images and bundles (default: `./intrinsic_asset_bundles`).
 * `--ros-distro <distro>`: The target ROS distro (default: `jazzy`).
 * `--no-cache`: Do not use cache when building container images.
 * `--builder-name <name>`: Custom Docker buildx builder name.
@@ -47,7 +47,7 @@ intrinsic_sdk_build container \
   --skill_package <package_name> \
   --skill_type <cpp|python>
 ```
-*Outputs: `./images/<skill_name>/<skill_name>.tar`*
+*Outputs: `./intrinsic_asset_bundles/<skill_name>/<skill_name>.tar`*
 
 ### 2. Build the Bundle
 Bundles the container image along with its manifest using the `inbuild` compiler:
@@ -57,7 +57,7 @@ intrinsic_sdk_build bundle \
   --skill_package <package_name> \
   --manifest_path <path_to_manifest>
 ```
-*Outputs: `./images/<skill_name>/<skill_name>.bundle.tar`*
+*Outputs: `./intrinsic_asset_bundles/<skill_name>/<skill_name>.bundle.tar`*
 
 ---
 

--- a/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py
+++ b/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py
@@ -32,11 +32,11 @@ COMMON_ARGUMENTS = {
             'help': 'ROS distro to use (default: jazzy)'
         }
     },
-    'images_dir': {
-        'flags': ('--images-dir', '--images_dir'),
+    'bundle_dir': {
+        'flags': ('--bundle-dir', '--bundle_dir', '--images-dir', '--images_dir'),
         'kwargs': {
-            'default': './images',
-            'help': 'Directory to store images and bundles (default: ./images)'
+            'default': './intrinsic_asset_bundles',
+            'help': 'Directory to store built bundles (default: ./intrinsic_asset_bundles)'
         }
     },
     'builder_name': {
@@ -165,7 +165,11 @@ def build_container(args):
         return
 
     tag = f'{package}:{name}'
-    images_dir = args.images_dir or './images'
+    bundle_dir = (
+        getattr(args, 'bundle_dir', None)
+        or getattr(args, 'images_dir', None)
+        or './intrinsic_asset_bundles'
+    )
     dockerfile = os.path.realpath(dockerfile)
 
     # Ensure .dockerignore exists to avoid sending large directories to build context
@@ -190,7 +194,7 @@ def build_container(args):
         ])
         run_command(['docker', 'buildx', 'use', builder_name])
 
-    tar_dir = os.path.join(images_dir, name)
+    tar_dir = os.path.join(bundle_dir, name)
     os.makedirs(tar_dir, exist_ok=True)
     tar_path = os.path.join(tar_dir, f'{name}.tar')
 
@@ -263,8 +267,12 @@ def build_bundle(args):
         print('Error: Must specify --manifest_path.')
         return
 
-    images_dir = args.images_dir or './images'
-    tar_path = os.path.join(images_dir, name, f'{name}.tar')
+    bundle_dir = (
+        getattr(args, 'bundle_dir', None)
+        or getattr(args, 'images_dir', None)
+        or './intrinsic_asset_bundles'
+    )
+    tar_path = os.path.join(bundle_dir, name, f'{name}.tar')
 
     if not os.path.exists(tar_path):
         print(f'Error: Image tar not found at {tar_path}. Run build-container first.')
@@ -277,7 +285,7 @@ def build_bundle(args):
     container_name = f'temp_container_{name}'
     run_command(['podman', 'create', '--replace', '--name', container_name, f'{package}:{name}'])
 
-    desc_path = os.path.join(images_dir, name, f'{name}_protos.desc')
+    desc_path = os.path.join(bundle_dir, name, f'{name}_protos.desc')
     if args.service_name:
         paths_to_try = [
             f'/opt/ros/overlay/install/share/{package}/{name}_protos.desc',
@@ -326,7 +334,7 @@ def build_bundle(args):
         '--file_descriptor_set', desc_path,
         '--manifest', args.manifest_path,
         '--oci_image', tar_path,
-        '--output', os.path.join(images_dir, name, f'{name}.bundle.tar')
+        '--output', os.path.join(bundle_dir, name, f'{name}.bundle.tar')
     ])
 
     if args.default_config:
@@ -341,7 +349,7 @@ def main():
 
     # Build container parser
     parser_container = subparsers.add_parser('container', help='Build container')
-    add_common_argument(parser_container, 'images_dir')
+    add_common_argument(parser_container, 'bundle_dir')
     add_common_argument(parser_container, 'builder_name')
     parser_container.add_argument('--service_name')
     parser_container.add_argument('--service_package')
@@ -367,7 +375,7 @@ def main():
 
     # Build bundle parser
     parser_bundle = subparsers.add_parser('bundle', help='Build bundle')
-    add_common_argument(parser_bundle, 'images_dir')
+    add_common_argument(parser_bundle, 'bundle_dir')
     add_common_argument(
         parser_bundle, 'builder_name',
         help='Ignored, for backward compatibility with scripts'

--- a/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py
+++ b/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py
@@ -23,6 +23,59 @@ import urllib.request
 
 from ament_index_python.packages import get_package_share_directory
 
+# Shared argument definitions for command-line parser and colcon verb
+COMMON_ARGUMENTS = {
+    'ros_distro': {
+        'flags': ('--ros-distro', '--ros_distro'),
+        'kwargs': {
+            'default': 'jazzy',
+            'help': 'ROS distro to use (default: jazzy)'
+        }
+    },
+    'images_dir': {
+        'flags': ('--images-dir', '--images_dir'),
+        'kwargs': {
+            'default': './images',
+            'help': 'Directory to store images and bundles (default: ./images)'
+        }
+    },
+    'builder_name': {
+        'flags': ('--builder-name', '--builder_name'),
+        'kwargs': {
+            'default': 'container-builder',
+            'help': 'Name of the buildx builder to use'
+        }
+    },
+    'no_cache': {
+        'flags': ('--no-cache',),
+        'kwargs': {
+            'action': 'store_true',
+            'help': 'Do not use cache when building the image'
+        }
+    },
+    'keep_builder': {
+        'flags': ('--keep-builder',),
+        'kwargs': {
+            'action': 'store_true',
+            'help': 'Do not stop the buildx builder after build'
+        }
+    },
+    'default_config': {
+        'flags': ('--default-config', '--default_config'),
+        'kwargs': {
+            'help': 'Default configuration file for the bundle'
+        }
+    }
+}
+
+
+def add_common_argument(parser, name, **kwargs_overrides):
+    """Add a common argument to the parser, with optional overrides."""
+    spec = COMMON_ARGUMENTS[name]
+    kwargs = spec['kwargs'].copy()
+    kwargs.update(kwargs_overrides)
+    parser.add_argument(*spec['flags'], **kwargs)
+
 
 def run_command(cmd, check=True):
     assert isinstance(cmd, list), 'cmd must be a list'
@@ -288,27 +341,21 @@ def main():
 
     # Build container parser
     parser_container = subparsers.add_parser('container', help='Build container')
-    parser_container.add_argument('--images_dir', default='./images')
-    parser_container.add_argument('--builder_name', default='container-builder')
+    add_common_argument(parser_container, 'images_dir')
+    add_common_argument(parser_container, 'builder_name')
     parser_container.add_argument('--service_name')
     parser_container.add_argument('--service_package')
     parser_container.add_argument('--skill_name')
     parser_container.add_argument('--skill_package')
     parser_container.add_argument('--dockerfile')
     parser_container.add_argument('--dependencies')
-    parser_container.add_argument('--ros_distro', default='jazzy')
+    add_common_argument(parser_container, 'ros_distro')
     parser_container.add_argument('--skill_executable')
     parser_container.add_argument('--skill_config')
     parser_container.add_argument('--skill_asset_id_org')
     parser_container.add_argument('--skill_type', choices=['cpp', 'python'], default='cpp')
-    parser_container.add_argument(
-        '--no-cache', action='store_true',
-        help='Do not use cache when building the image'
-    )
-    parser_container.add_argument(
-        '--keep-builder', action='store_true',
-        help='Do not stop the buildx builder after build'
-    )
+    add_common_argument(parser_container, 'no_cache')
+    add_common_argument(parser_container, 'keep_builder')
     parser_container.add_argument(
         '--source-dir',
         help='Override SOURCE_DIR build arg in service.Dockerfile'
@@ -320,9 +367,9 @@ def main():
 
     # Build bundle parser
     parser_bundle = subparsers.add_parser('bundle', help='Build bundle')
-    parser_bundle.add_argument('--images_dir', default='./images')
-    parser_bundle.add_argument(
-        '--builder_name', default='container-builder',
+    add_common_argument(parser_bundle, 'images_dir')
+    add_common_argument(
+        parser_bundle, 'builder_name',
         help='Ignored, for backward compatibility with scripts'
     )
     parser_bundle.add_argument('--service_name')
@@ -330,7 +377,7 @@ def main():
     parser_bundle.add_argument('--skill_name')
     parser_bundle.add_argument('--skill_package')
     parser_bundle.add_argument('--manifest_path', required=True)
-    parser_bundle.add_argument('--default_config')
+    add_common_argument(parser_bundle, 'default_config')
 
     args = parser.parse_args()
 

--- a/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py
+++ b/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py
@@ -97,11 +97,7 @@ def get_sdk_version():
 
 
 def download_inbuild(sdk_version, dest_dir='.'):
-    # Map specific SDK versions to patch releases if binaries were not uploaded for the base tag
-    version_mapping = {
-        'v1.31.20260427': 'v1.31.20260427.1'
-    }
-    download_version = version_mapping.get(sdk_version, sdk_version)
+    download_version = sdk_version
 
     system = platform.system().lower()
     machine = platform.machine().lower()

--- a/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py
+++ b/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import urllib.request
@@ -24,7 +25,7 @@ from ament_index_python.packages import get_package_share_directory
 
 
 def run_command(cmd, check=True):
-    assert isinstance(cmd, list), "cmd must be a list"
+    assert isinstance(cmd, list), 'cmd must be a list'
     print(f"Running: {' '.join(cmd)}")
     return subprocess.run(cmd, check=check)
 
@@ -43,6 +44,12 @@ def get_sdk_version():
 
 
 def download_inbuild(sdk_version, dest_dir='.'):
+    # Map specific SDK versions to patch releases if binaries were not uploaded for the base tag
+    version_mapping = {
+        'v1.31.20260427': 'v1.31.20260427.1'
+    }
+    download_version = version_mapping.get(sdk_version, sdk_version)
+
     system = platform.system().lower()
     machine = platform.machine().lower()
 
@@ -63,7 +70,10 @@ def download_inbuild(sdk_version, dest_dir='.'):
     inbuild_path = os.path.join(dest_dir, 'inbuild' + ext)
 
     if not os.path.exists(inbuild_path):
-        url = f'https://github.com/intrinsic-ai/sdk/releases/download/{sdk_version}/{binary_name}'
+        url = (
+            f'https://github.com/intrinsic-ai/sdk/releases/download/'
+            f'{download_version}/{binary_name}'
+        )
         print(f'Downloading inbuild from {url} to {inbuild_path}...')
         try:
             urllib.request.urlretrieve(url, inbuild_path)
@@ -103,6 +113,7 @@ def build_container(args):
 
     tag = f'{package}:{name}'
     images_dir = args.images_dir or './images'
+    dockerfile = os.path.realpath(dockerfile)
 
     # Ensure .dockerignore exists to avoid sending large directories to build context
     dockerignore_path = '.dockerignore'
@@ -119,8 +130,11 @@ def build_container(args):
     try:
         run_command(['docker', 'buildx', 'inspect', '--builder', builder_name])
     except Exception:
-        print(f"Builder {builder_name} not found. Creating it...")
-        run_command(['docker', 'buildx', 'create', '--name', builder_name, '--driver', 'docker-container'])
+        print(f'Builder {builder_name} not found. Creating it...')
+        run_command([
+            'docker', 'buildx', 'create', '--name', builder_name,
+            '--driver', 'docker-container'
+        ])
         run_command(['docker', 'buildx', 'use', builder_name])
 
     tar_dir = os.path.join(images_dir, name)
@@ -135,11 +149,11 @@ def build_container(args):
 
         # Output flag
         output_arg = (
-            f"type=docker,"
-            f"dest={tar_path},"
-            f"compression=zstd,"
-            f"push=false,"
-            f"name={tag}"
+            f'type=docker,'
+            f'dest={tar_path},'
+            f'compression=zstd,'
+            f'push=false,'
+            f'name={tag}'
         )
         cmd.extend(['--output', output_arg])
 
@@ -223,10 +237,13 @@ def build_bundle(args):
                 success = True
                 break
             except subprocess.CalledProcessError:
-                print(f"Failed to copy from {src_path}, trying next path...")
+                print(f'Failed to copy from {src_path}, trying next path...')
                 continue
         if not success:
-            raise subprocess.CalledProcessError(1, f"Failed to copy descriptor file from any of the expected paths.")
+            raise subprocess.CalledProcessError(
+                1,
+                'Failed to copy descriptor file from any of the expected paths.'
+            )
 
     else:
         src_path = f'/opt/{name}_workspace/install/share/{package}/{name}_protos.desc'
@@ -234,13 +251,16 @@ def build_bundle(args):
 
     run_command(['podman', 'rm', '-f', container_name])
 
-    # Get SDK version and download inbuild
-    sdk_version = get_sdk_version()
-    if not sdk_version:
-        print('Error: Could not determine SDK version.')
-        return
+    # Check if inbuild is in PATH or current directory
+    inbuild_path = shutil.which('inbuild') or './inbuild'
 
-    inbuild_path = download_inbuild(sdk_version)
+    if inbuild_path == './inbuild' and not os.path.exists('./inbuild'):
+        sdk_version = get_sdk_version()
+        if not sdk_version:
+            print('Error: Could not determine SDK version.')
+            return
+
+        inbuild_path = download_inbuild(sdk_version)
 
     # Build bundle
     inbuild_cmd = [inbuild_path]
@@ -260,9 +280,6 @@ def build_bundle(args):
         inbuild_cmd.extend(['--default_config', args.default_config])
 
     run_command(inbuild_cmd)
-
-    bundle_path = os.path.join(images_dir, name, f'{name}.bundle.tar')
-
 
 
 def main():
@@ -284,15 +301,30 @@ def main():
     parser_container.add_argument('--skill_config')
     parser_container.add_argument('--skill_asset_id_org')
     parser_container.add_argument('--skill_type', choices=['cpp', 'python'], default='cpp')
-    parser_container.add_argument('--no-cache', action='store_true', help='Do not use cache when building the image')
-    parser_container.add_argument('--keep-builder', action='store_true', help='Do not stop the buildx builder after build')
-    parser_container.add_argument('--source-dir', help='Override SOURCE_DIR build arg in service.Dockerfile')
-    parser_container.add_argument('--overlay-source', help='Override OVERLAY_SOURCE build arg in service.Dockerfile')
+    parser_container.add_argument(
+        '--no-cache', action='store_true',
+        help='Do not use cache when building the image'
+    )
+    parser_container.add_argument(
+        '--keep-builder', action='store_true',
+        help='Do not stop the buildx builder after build'
+    )
+    parser_container.add_argument(
+        '--source-dir',
+        help='Override SOURCE_DIR build arg in service.Dockerfile'
+    )
+    parser_container.add_argument(
+        '--overlay-source',
+        help='Override OVERLAY_SOURCE build arg in service.Dockerfile'
+    )
 
     # Build bundle parser
     parser_bundle = subparsers.add_parser('bundle', help='Build bundle')
     parser_bundle.add_argument('--images_dir', default='./images')
-    parser_bundle.add_argument('--builder_name', default='container-builder', help='Ignored, for backward compatibility with scripts')
+    parser_bundle.add_argument(
+        '--builder_name', default='container-builder',
+        help='Ignored, for backward compatibility with scripts'
+    )
     parser_bundle.add_argument('--service_name')
     parser_bundle.add_argument('--service_package')
     parser_bundle.add_argument('--skill_name')

--- a/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/colcon_verb.py
+++ b/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/colcon_verb.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Intrinsic Innovation LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from pathlib import Path
+import re
+
+from colcon_core.package_selection import add_arguments as add_package_selection_arguments
+from colcon_core.package_selection import get_packages
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.verb import VerbExtensionPoint
+
+from intrinsic_sdk_bundle_library_py.build import build_bundle, build_container
+
+
+class BundleVerb(VerbExtensionPoint):
+    """Bundle skills or services from a ROS workspace."""
+
+    def __init__(self):
+        super().__init__()
+        satisfies_version(VerbExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):
+        # Register package selection arguments (e.g. --packages-select)
+        add_package_selection_arguments(parser)
+
+        # Verb-specific arguments
+        parser.add_argument(
+            '--ros-distro', default='jazzy',
+            help='ROS distro to use (default: jazzy)'
+        )
+        parser.add_argument(
+            '--images-dir', default='./images',
+            help='Directory to store images and bundles (default: ./images)'
+        )
+        parser.add_argument(
+            '--builder-name', default='container-builder',
+            help='Name of the buildx builder to use'
+        )
+        parser.add_argument(
+            '--no-cache', action='store_true',
+            help='Do not use cache when building the image'
+        )
+        parser.add_argument(
+            '--keep-builder', action='store_true',
+            help='Do not stop the buildx builder after build'
+        )
+        parser.add_argument('--default-config', help='Default configuration file for the bundle')
+
+    def main(self, *, context):
+        args = context.args
+
+        # Get all packages and filter selected
+        decorators = get_packages(args)
+        selected_decorators = [d for d in decorators if d.selected]
+
+        if not selected_decorators:
+            print('No packages selected or found in the workspace.')
+            return 0
+
+        # Scan for packages with manifests
+        bundlable_packages = []
+        for decorator in selected_decorators:
+            pkg_path = Path(decorator.descriptor.path)
+            # Find manifest file
+            manifests = list(pkg_path.glob('*.manifest.textproto'))
+            if not manifests:
+                continue
+
+            if len(manifests) > 1:
+                print(
+                    f'Warning: Multiple manifest files found in {decorator.descriptor.name}, '
+                    f'using the first one: {manifests[0]}'
+                )
+
+            manifest_path = manifests[0]
+
+            # Parse manifest
+            try:
+                with open(manifest_path, 'r') as f:
+                    content = f.read()
+            except Exception as e:
+                print(f'Error reading manifest {manifest_path}: {e}')
+                continue
+
+            info = self._parse_manifest(content)
+            info['manifest_path'] = str(manifest_path.resolve())
+            info['package_name'] = decorator.descriptor.name
+
+            bundlable_packages.append(info)
+
+        if not bundlable_packages:
+            print('No packages with a *.manifest.textproto file were selected.')
+            return 0
+
+        print(f'Found {len(bundlable_packages)} package(s) to bundle:')
+        for pkg in bundlable_packages:
+            skill_type = pkg['skill_type']
+            type_str = 'service' if pkg['is_service'] else f'skill ({skill_type})'
+            pkg_name = pkg['package_name']
+            print(f'  - {pkg_name} ({type_str})')
+
+        # Now build each package
+        for pkg in bundlable_packages:
+            pkg_name = pkg['package_name']
+            print(f'\n--- Processing {pkg_name} ---')
+
+            # Construct arguments for build_container
+            container_args = argparse.Namespace(
+                command='container',
+                images_dir=args.images_dir,
+                builder_name=args.builder_name,
+                ros_distro=args.ros_distro,
+                no_cache=args.no_cache,
+                keep_builder=args.keep_builder,
+                dockerfile=None,
+                dependencies=None,
+                source_dir=None,
+                overlay_source=None,
+
+                # Skill specific
+                skill_name=None if pkg['is_service'] else pkg['name'],
+                skill_package=None if pkg['is_service'] else pkg['package_name'],
+                skill_executable=None,  # Will default in build.py
+                skill_config=None,      # Will default in build.py
+                skill_asset_id_org=pkg['package_org'] if not pkg['is_service'] else None,
+                skill_type=pkg['skill_type'] if not pkg['is_service'] else 'cpp',
+
+                # Service specific
+                service_name=pkg['name'] if pkg['is_service'] else None,
+                service_package=pkg['package_name'] if pkg['is_service'] else None
+            )
+
+            # Build container
+            try:
+                build_container(container_args)
+            except Exception as e:
+                print(f'Error building container for {pkg_name}: {e}')
+                return 1
+
+            # Construct arguments for build_bundle
+            bundle_args = argparse.Namespace(
+                command='bundle',
+                images_dir=args.images_dir,
+                builder_name=args.builder_name,  # Ignored
+
+                skill_name=None if pkg['is_service'] else pkg['name'],
+                skill_package=None if pkg['is_service'] else pkg['package_name'],
+                service_name=pkg['name'] if pkg['is_service'] else None,
+                service_package=pkg['package_name'] if pkg['is_service'] else None,
+
+                manifest_path=pkg['manifest_path'],
+                default_config=args.default_config
+            )
+
+            # Build bundle
+            try:
+                build_bundle(bundle_args)
+            except Exception as e:
+                print(f'Error building bundle for {pkg_name}: {e}')
+                return 1
+
+        print('\nAll bundles built successfully!')
+        return 0
+
+    def _parse_manifest(self, content):
+        is_service = 'service_def' in content
+
+        match_name = re.search(r'id\s*\{\s*[^^{}]*name:\s*"([^"]+)"', content, re.DOTALL)
+        name = match_name.group(1) if match_name else None
+
+        match_pkg = re.search(r'id\s*\{\s*[^^{}]*package:\s*"([^"]+)"', content, re.DOTALL)
+        package_org = match_pkg.group(1) if match_pkg else None
+
+        skill_type = None
+        if not is_service:
+            if 'python_config' in content:
+                skill_type = 'python'
+            else:
+                # Default to cpp if cc_config or not specified
+                skill_type = 'cpp'
+
+        return {
+            'is_service': is_service,
+            'name': name,
+            'package_org': package_org,
+            'skill_type': skill_type
+        }

--- a/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/colcon_verb.py
+++ b/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/colcon_verb.py
@@ -41,7 +41,7 @@ class BundleVerb(VerbExtensionPoint):
 
         # Verb-specific arguments
         add_common_argument(parser, 'ros_distro')
-        add_common_argument(parser, 'images_dir')
+        add_common_argument(parser, 'bundle_dir')
         add_common_argument(parser, 'builder_name')
         add_common_argument(parser, 'no_cache')
         add_common_argument(parser, 'keep_builder')
@@ -108,7 +108,7 @@ class BundleVerb(VerbExtensionPoint):
             # Construct arguments for build_container
             container_args = argparse.Namespace(
                 command='container',
-                images_dir=args.images_dir,
+                images_dir=args.bundle_dir,
                 builder_name=args.builder_name,
                 ros_distro=args.ros_distro,
                 no_cache=args.no_cache,
@@ -141,7 +141,7 @@ class BundleVerb(VerbExtensionPoint):
             # Construct arguments for build_bundle
             bundle_args = argparse.Namespace(
                 command='bundle',
-                images_dir=args.images_dir,
+                images_dir=args.bundle_dir,
                 builder_name=args.builder_name,  # Ignored
 
                 skill_name=None if pkg['is_service'] else pkg['name'],

--- a/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/colcon_verb.py
+++ b/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/colcon_verb.py
@@ -21,7 +21,11 @@ from colcon_core.package_selection import get_packages
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.verb import VerbExtensionPoint
 
-from intrinsic_sdk_bundle_library_py.build import build_bundle, build_container
+from intrinsic_sdk_bundle_library_py.build import (
+    add_common_argument,
+    build_bundle,
+    build_container,
+)
 
 
 class BundleVerb(VerbExtensionPoint):
@@ -36,27 +40,12 @@ class BundleVerb(VerbExtensionPoint):
         add_package_selection_arguments(parser)
 
         # Verb-specific arguments
-        parser.add_argument(
-            '--ros-distro', default='jazzy',
-            help='ROS distro to use (default: jazzy)'
-        )
-        parser.add_argument(
-            '--images-dir', default='./images',
-            help='Directory to store images and bundles (default: ./images)'
-        )
-        parser.add_argument(
-            '--builder-name', default='container-builder',
-            help='Name of the buildx builder to use'
-        )
-        parser.add_argument(
-            '--no-cache', action='store_true',
-            help='Do not use cache when building the image'
-        )
-        parser.add_argument(
-            '--keep-builder', action='store_true',
-            help='Do not stop the buildx builder after build'
-        )
-        parser.add_argument('--default-config', help='Default configuration file for the bundle')
+        add_common_argument(parser, 'ros_distro')
+        add_common_argument(parser, 'images_dir')
+        add_common_argument(parser, 'builder_name')
+        add_common_argument(parser, 'no_cache')
+        add_common_argument(parser, 'keep_builder')
+        add_common_argument(parser, 'default_config')
 
     def main(self, *, context):
         args = context.args

--- a/intrinsic_sdk_bundle_library_py/package.xml
+++ b/intrinsic_sdk_bundle_library_py/package.xml
@@ -14,6 +14,9 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
+  <exec_depend>colcon-core</exec_depend>
+  <exec_depend>colcon-package-selection</exec_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/intrinsic_sdk_bundle_library_py/resource/sdk_version.json
+++ b/intrinsic_sdk_bundle_library_py/resource/sdk_version.json
@@ -1,4 +1,4 @@
 {
-	"sdk_version": "v1.31.20260427",
-	"sdk_checksum": "SHA256=a9bfa0a40dc8d79b7e33594e2a0a94e406747da0c2b7e3d62e926163e0848034"
+	"sdk_version": "v1.31.20260427.1",
+	"sdk_checksum": "SHA256=c9d79c0a37e776c1631217aa8ed65a13b1063301fea4aa75e22861c2a6074496"
 }

--- a/intrinsic_sdk_bundle_library_py/resource/service.Dockerfile
+++ b/intrinsic_sdk_bundle_library_py/resource/service.Dockerfile
@@ -47,6 +47,10 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     && apt-get update \
     && echo "python3-absl-py:" > /etc/ros/rosdep/custom.yaml \
     && echo "  ubuntu: [python3-absl]" >> /etc/ros/rosdep/custom.yaml \
+    && echo "colcon-core:" >> /etc/ros/rosdep/custom.yaml \
+    && echo "  ubuntu: [python3-colcon-core]" >> /etc/ros/rosdep/custom.yaml \
+    && echo "colcon-package-selection:" >> /etc/ros/rosdep/custom.yaml \
+    && echo "  ubuntu: [python3-colcon-package-selection]" >> /etc/ros/rosdep/custom.yaml \
     && echo "yaml file:///etc/ros/rosdep/custom.yaml" > /etc/ros/rosdep/sources.list.d/50-custom.list \
     && rosdep update \
     && rosdep install --from-paths src --ignore-src -r -y \

--- a/intrinsic_sdk_bundle_library_py/resource/skill.Dockerfile
+++ b/intrinsic_sdk_bundle_library_py/resource/skill.Dockerfile
@@ -74,6 +74,10 @@ RUN \
     && echo "  ubuntu: [python3-absl]" >> /etc/ros/rosdep/custom.yaml \
     && echo "python3-retrying:" >> /etc/ros/rosdep/custom.yaml \
     && echo "  ubuntu: [python3-retrying]" >> /etc/ros/rosdep/custom.yaml \
+    && echo "colcon-core:" >> /etc/ros/rosdep/custom.yaml \
+    && echo "  ubuntu: [python3-colcon-core]" >> /etc/ros/rosdep/custom.yaml \
+    && echo "colcon-package-selection:" >> /etc/ros/rosdep/custom.yaml \
+    && echo "  ubuntu: [python3-colcon-package-selection]" >> /etc/ros/rosdep/custom.yaml \
     && echo "yaml file:///etc/ros/rosdep/custom.yaml" > /etc/ros/rosdep/sources.list.d/50-custom.list \
     && rosdep update \
     && cd $SKILL_WORKSPACE \
@@ -136,6 +140,10 @@ RUN \
     && echo "  ubuntu: [python3-absl]" >> /etc/ros/rosdep/custom.yaml \
     && echo "python3-retrying:" >> /etc/ros/rosdep/custom.yaml \
     && echo "  ubuntu: [python3-retrying]" >> /etc/ros/rosdep/custom.yaml \
+    && echo "colcon-core:" >> /etc/ros/rosdep/custom.yaml \
+    && echo "  ubuntu: [python3-colcon-core]" >> /etc/ros/rosdep/custom.yaml \
+    && echo "colcon-package-selection:" >> /etc/ros/rosdep/custom.yaml \
+    && echo "  ubuntu: [python3-colcon-package-selection]" >> /etc/ros/rosdep/custom.yaml \
     && echo "yaml file:///etc/ros/rosdep/custom.yaml" > /etc/ros/rosdep/sources.list.d/50-custom.list \
     && rosdep update \
     && cd $SKILL_WORKSPACE \

--- a/intrinsic_sdk_bundle_library_py/setup.cfg
+++ b/intrinsic_sdk_bundle_library_py/setup.cfg
@@ -2,3 +2,13 @@
 script_dir=$base/lib/intrinsic_sdk_bundle_library_py
 [install]
 install_scripts=$base/lib/intrinsic_sdk_bundle_library_py
+
+[tool:pytest]
+norecursedirs = test/functional_tests
+
+[flake8]
+exclude = test/functional_tests
+    .git
+    __pycache__
+    build
+    dist

--- a/intrinsic_sdk_bundle_library_py/setup.py
+++ b/intrinsic_sdk_bundle_library_py/setup.py
@@ -48,5 +48,8 @@ setup(
         'console_scripts': [
             'intrinsic_sdk_build = intrinsic_sdk_bundle_library_py.build:main',
         ],
+        'colcon_core.verb': [
+            'bundle = intrinsic_sdk_bundle_library_py.colcon_verb:BundleVerb',
+        ],
     },
 )

--- a/intrinsic_sdk_bundle_library_py/setup.py
+++ b/intrinsic_sdk_bundle_library_py/setup.py
@@ -49,7 +49,7 @@ setup(
             'intrinsic_sdk_build = intrinsic_sdk_bundle_library_py.build:main',
         ],
         'colcon_core.verb': [
-            'bundle = intrinsic_sdk_bundle_library_py.colcon_verb:BundleVerb',
+            'intrinsic_bundle = intrinsic_sdk_bundle_library_py.colcon_verb:BundleVerb',
         ],
     },
 )

--- a/intrinsic_sdk_bundle_library_py/test/README.md
+++ b/intrinsic_sdk_bundle_library_py/test/README.md
@@ -31,7 +31,7 @@ To test building and bundling the Python skill:
 
 **Using the Colcon Extension (Recommended):**
 ```bash
-colcon bundle --packages-select test_python_skill
+colcon intrinsic_bundle --packages-select test_python_skill
 ```
 
 **Using the Standalone CLI (Manual):**
@@ -54,7 +54,7 @@ To test building and bundling the C++ skill:
 
 **Using the Colcon Extension (Recommended):**
 ```bash
-colcon bundle --packages-select test_cpp_skill
+colcon intrinsic_bundle --packages-select test_cpp_skill
 ```
 
 **Using the Standalone CLI (Manual):**
@@ -77,7 +77,7 @@ To test building and bundling the Python service:
 
 **Using the Colcon Extension (Recommended):**
 ```bash
-colcon bundle --packages-select test_python_service
+colcon intrinsic_bundle --packages-select test_python_service
 ```
 
 **Using the Standalone CLI (Manual):**
@@ -100,7 +100,7 @@ To test building and bundling the C++ service:
 
 **Using the Colcon Extension (Recommended):**
 ```bash
-colcon bundle --packages-select test_cpp_service
+colcon intrinsic_bundle --packages-select test_cpp_service
 ```
 
 **Using the Standalone CLI (Manual):**

--- a/intrinsic_sdk_bundle_library_py/test/README.md
+++ b/intrinsic_sdk_bundle_library_py/test/README.md
@@ -24,8 +24,17 @@ pytest test/test_build.py
 ## 2. Functional Tests
 To verify that the build and bundle workflow works correctly for both C++ and Python, we use test skills and services located in the [functional_tests](./functional_tests) directory.
 
+Ensure you have sourced your workspace (`source install/setup.bash`) before running these tests.
+
 ### Python Skill Test
-To test building and bundling a Python skill:
+To test building and bundling the Python skill:
+
+**Using the Colcon Extension (Recommended):**
+```bash
+colcon bundle --packages-select test_python_skill
+```
+
+**Using the Standalone CLI (Manual):**
 ```bash
 # 1. Build container (OCI image)
 python3 src/sdk-ros/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py container \
@@ -41,7 +50,14 @@ python3 src/sdk-ros/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library
 ```
 
 ### C++ Skill Test
-To test building and bundling a C++ skill:
+To test building and bundling the C++ skill:
+
+**Using the Colcon Extension (Recommended):**
+```bash
+colcon bundle --packages-select test_cpp_skill
+```
+
+**Using the Standalone CLI (Manual):**
 ```bash
 # 1. Build container
 python3 src/sdk-ros/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py container \
@@ -57,7 +73,14 @@ python3 src/sdk-ros/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library
 ```
 
 ### Python Service Test
-To test building and bundling a Python service:
+To test building and bundling the Python service:
+
+**Using the Colcon Extension (Recommended):**
+```bash
+colcon bundle --packages-select test_python_service
+```
+
+**Using the Standalone CLI (Manual):**
 ```bash
 # 1. Build container
 python3 src/sdk-ros/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py container \
@@ -72,9 +95,15 @@ python3 src/sdk-ros/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library
   --default_config src/sdk-ros/intrinsic_sdk_bundle_library_py/test/functional_tests/test_python_service/test_python_service_default_config.pbtxt
 ```
 
-
 ### C++ Service Test
-To test building and bundling a C++ service:
+To test building and bundling the C++ service:
+
+**Using the Colcon Extension (Recommended):**
+```bash
+colcon bundle --packages-select test_cpp_service
+```
+
+**Using the Standalone CLI (Manual):**
 ```bash
 # 1. Build container
 python3 src/sdk-ros/intrinsic_sdk_bundle_library_py/intrinsic_sdk_bundle_library_py/build.py container \

--- a/intrinsic_sdk_bundle_library_py/test/README.md
+++ b/intrinsic_sdk_bundle_library_py/test/README.md
@@ -125,7 +125,7 @@ Once you have built the bundle, you can install and verify it on the platform.
 ### Python Skill
 To install the Python skill bundle:
 ```bash
-inctl skill install images/test_python_skill/test_python_skill.bundle.tar \
+inctl skill install intrinsic_asset_bundles/test_python_skill/test_python_skill.bundle.tar \
   --org=<YOUR_ORGANIZATION> \
   --solution=<YOUR_SOLUTION_ID>
 ```
@@ -139,7 +139,7 @@ To verify that it works correctly, check the skill logs for:
 ### C++ Skill
 To install the C++ skill bundle:
 ```bash
-inctl skill install images/test_cpp_skill/test_cpp_skill.bundle.tar \
+inctl skill install intrinsic_asset_bundles/test_cpp_skill/test_cpp_skill.bundle.tar \
   --org=<YOUR_ORGANIZATION> \
   --solution=<YOUR_SOLUTION_ID>
 ```
@@ -150,7 +150,7 @@ To verify that it works correctly, check the skill logs for:
 ### Python Service
 To install the Python service bundle:
 ```bash
-inctl asset install images/test_python_service/test_python_service.bundle.tar \
+inctl asset install intrinsic_asset_bundles/test_python_service/test_python_service.bundle.tar \
   --org=<YOUR_ORGANIZATION> \
   --solution=<YOUR_SOLUTION_ID>
 ```
@@ -164,7 +164,7 @@ To verify that it works correctly:
 ### C++ Service
 To install the C++ service bundle:
 ```bash
-inctl asset install images/test_cpp_service/test_cpp_service.bundle.tar \
+inctl asset install intrinsic_asset_bundles/test_cpp_service/test_cpp_service.bundle.tar \
   --org=<YOUR_ORGANIZATION> \
   --solution=<YOUR_SOLUTION_ID>
 ```

--- a/intrinsic_sdk_bundle_library_py/test/test_arguments.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_arguments.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Intrinsic Innovation LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+import unittest
+
+try:
+    from intrinsic_sdk_bundle_library_py.build import add_common_argument, COMMON_ARGUMENTS
+except ImportError:
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    from intrinsic_sdk_bundle_library_py.build import add_common_argument, COMMON_ARGUMENTS
+
+
+class TestArguments(unittest.TestCase):
+
+    def test_common_arguments_keys(self):
+        expected_keys = {
+            'ros_distro',
+            'images_dir',
+            'builder_name',
+            'no_cache',
+            'keep_builder',
+            'default_config',
+        }
+        self.assertEqual(set(COMMON_ARGUMENTS.keys()), expected_keys)
+
+    def test_add_common_argument_ros_distro(self):
+        parser = argparse.ArgumentParser()
+        add_common_argument(parser, 'ros_distro')
+
+        # Test default
+        args = parser.parse_args([])
+        self.assertEqual(args.ros_distro, 'jazzy')
+
+        # Test dash flag
+        args = parser.parse_args(['--ros-distro', 'rolling'])
+        self.assertEqual(args.ros_distro, 'rolling')
+
+        # Test underscore flag
+        args = parser.parse_args(['--ros_distro', 'iron'])
+        self.assertEqual(args.ros_distro, 'iron')
+
+    def test_add_common_argument_images_dir(self):
+        parser = argparse.ArgumentParser()
+        add_common_argument(parser, 'images_dir')
+
+        # Test default
+        args = parser.parse_args([])
+        self.assertEqual(args.images_dir, './images')
+
+        # Test dash flag
+        args = parser.parse_args(['--images-dir', '/tmp/foo'])
+        self.assertEqual(args.images_dir, '/tmp/foo')
+
+        # Test underscore flag
+        args = parser.parse_args(['--images_dir', '/tmp/bar'])
+        self.assertEqual(args.images_dir, '/tmp/bar')
+
+    def test_add_common_argument_builder_name(self):
+        parser = argparse.ArgumentParser()
+        add_common_argument(parser, 'builder_name')
+
+        # Test default
+        args = parser.parse_args([])
+        self.assertEqual(args.builder_name, 'container-builder')
+
+        # Test dash flag
+        args = parser.parse_args(['--builder-name', 'custom-builder'])
+        self.assertEqual(args.builder_name, 'custom-builder')
+
+        # Test underscore flag
+        args = parser.parse_args(['--builder_name', 'another-builder'])
+        self.assertEqual(args.builder_name, 'another-builder')
+
+    def test_add_common_argument_no_cache(self):
+        parser = argparse.ArgumentParser()
+        add_common_argument(parser, 'no_cache')
+
+        # Test default
+        args = parser.parse_args([])
+        self.assertFalse(args.no_cache)
+
+        # Test flag
+        args = parser.parse_args(['--no-cache'])
+        self.assertTrue(args.no_cache)
+
+    def test_add_common_argument_keep_builder(self):
+        parser = argparse.ArgumentParser()
+        add_common_argument(parser, 'keep_builder')
+
+        # Test default
+        args = parser.parse_args([])
+        self.assertFalse(args.keep_builder)
+
+        # Test flag
+        args = parser.parse_args(['--keep-builder'])
+        self.assertTrue(args.keep_builder)
+
+    def test_add_common_argument_default_config(self):
+        parser = argparse.ArgumentParser()
+        add_common_argument(parser, 'default_config')
+
+        # Test default
+        args = parser.parse_args([])
+        self.assertIsNone(args.default_config)
+
+        # Test dash flag
+        args = parser.parse_args(['--default-config', 'config.pbtxt'])
+        self.assertEqual(args.default_config, 'config.pbtxt')
+
+        # Test underscore flag
+        args = parser.parse_args(['--default_config', 'another.pbtxt'])
+        self.assertEqual(args.default_config, 'another.pbtxt')
+
+    def test_kwargs_overrides(self):
+        parser = argparse.ArgumentParser()
+        add_common_argument(parser, 'builder_name', help='Custom help message')
+
+        # Verify parsing still works
+        args = parser.parse_args(['--builder-name', 'my-builder'])
+        self.assertEqual(args.builder_name, 'my-builder')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/intrinsic_sdk_bundle_library_py/test/test_arguments.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_arguments.py
@@ -29,7 +29,7 @@ class TestArguments(unittest.TestCase):
     def test_common_arguments_keys(self):
         expected_keys = {
             'ros_distro',
-            'images_dir',
+            'bundle_dir',
             'builder_name',
             'no_cache',
             'keep_builder',
@@ -53,21 +53,29 @@ class TestArguments(unittest.TestCase):
         args = parser.parse_args(['--ros_distro', 'iron'])
         self.assertEqual(args.ros_distro, 'iron')
 
-    def test_add_common_argument_images_dir(self):
+    def test_add_common_argument_bundle_dir(self):
         parser = argparse.ArgumentParser()
-        add_common_argument(parser, 'images_dir')
+        add_common_argument(parser, 'bundle_dir')
 
         # Test default
         args = parser.parse_args([])
-        self.assertEqual(args.images_dir, './images')
+        self.assertEqual(args.bundle_dir, './intrinsic_asset_bundles')
 
-        # Test dash flag
-        args = parser.parse_args(['--images-dir', '/tmp/foo'])
-        self.assertEqual(args.images_dir, '/tmp/foo')
+        # Test bundle dash flag
+        args = parser.parse_args(['--bundle-dir', '/tmp/foo'])
+        self.assertEqual(args.bundle_dir, '/tmp/foo')
 
-        # Test underscore flag
-        args = parser.parse_args(['--images_dir', '/tmp/bar'])
-        self.assertEqual(args.images_dir, '/tmp/bar')
+        # Test bundle underscore flag
+        args = parser.parse_args(['--bundle_dir', '/tmp/bar'])
+        self.assertEqual(args.bundle_dir, '/tmp/bar')
+
+        # Test legacy images dash flag
+        args = parser.parse_args(['--images-dir', '/tmp/baz'])
+        self.assertEqual(args.bundle_dir, '/tmp/baz')
+
+        # Test legacy images underscore flag
+        args = parser.parse_args(['--images_dir', '/tmp/qux'])
+        self.assertEqual(args.bundle_dir, '/tmp/qux')
 
     def test_add_common_argument_builder_name(self):
         parser = argparse.ArgumentParser()

--- a/intrinsic_sdk_bundle_library_py/test/test_build.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_build.py
@@ -1,7 +1,21 @@
+# Copyright 2026 Intrinsic Innovation LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
-import unittest
-from unittest.mock import patch, mock_open, MagicMock
 import sys
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
 
 try:
     from intrinsic_sdk_bundle_library_py import build
@@ -9,15 +23,24 @@ except ImportError:
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
     from intrinsic_sdk_bundle_library_py import build
 
+
 class TestBuild(unittest.TestCase):
 
+    @patch(
+        'intrinsic_sdk_bundle_library_py.build.get_package_share_directory',
+        return_value='/dummy/share/path'
+    )
     @patch('builtins.open', new_callable=mock_open, read_data='{"sdk_version": "v0.1.0"}')
-    def test_get_sdk_version(self, mock_file):
+    def test_get_sdk_version(self, mock_file, mock_get_share):
         version = build.get_sdk_version()
-        self.assertEqual(version, "v0.1.0")
+        self.assertEqual(version, 'v0.1.0')
 
-    @patch('builtins.open', side_effect=Exception("File not found"))
-    def test_get_sdk_version_error(self, mock_file):
+    @patch(
+        'intrinsic_sdk_bundle_library_py.build.get_package_share_directory',
+        return_value='/dummy/share/path'
+    )
+    @patch('builtins.open', side_effect=Exception('File not found'))
+    def test_get_sdk_version_error(self, mock_file, mock_get_share):
         version = build.get_sdk_version()
         self.assertIsNone(version)
 
@@ -26,9 +49,11 @@ class TestBuild(unittest.TestCase):
     @patch('os.path.exists', return_value=False)
     @patch('platform.system', return_value='Linux')
     @patch('platform.machine', return_value='x86_64')
-    def test_download_inbuild(self, mock_machine, mock_system, mock_exists, mock_chmod, mock_urlretrieve):
-        path = build.download_inbuild("v0.1.0")
-        self.assertEqual(path, "./inbuild")
+    def test_download_inbuild(
+        self, mock_machine, mock_system, mock_exists, mock_chmod, mock_urlretrieve
+    ):
+        path = build.download_inbuild('v0.1.0')
+        self.assertEqual(path, './inbuild')
         mock_urlretrieve.assert_called_once()
 
     @patch('subprocess.run')
@@ -41,14 +66,14 @@ class TestBuild(unittest.TestCase):
         args = MagicMock()
         args.service_name = None
         args.service_package = None
-        args.skill_name = "test_skill"
-        args.skill_package = "test_package"
+        args.skill_name = 'test_skill'
+        args.skill_package = 'test_package'
         args.dockerfile = None
-        args.images_dir = "./images"
-        args.builder_name = "test-builder"
+        args.images_dir = './images'
+        args.builder_name = 'test-builder'
         args.no_cache = False
-        args.ros_distro = "jazzy"
-        args.skill_type = "python"
+        args.ros_distro = 'jazzy'
+        args.skill_type = 'python'
         args.skill_executable = None
         args.skill_config = None
         args.skill_asset_id_org = None
@@ -57,7 +82,7 @@ class TestBuild(unittest.TestCase):
         mock_run_command.return_value = MagicMock()
 
         build.build_container(args)
-        
+
         calls = mock_run_command.call_args_list
         found_build = False
         for call in calls:
@@ -71,20 +96,22 @@ class TestBuild(unittest.TestCase):
     @patch('intrinsic_sdk_bundle_library_py.build.get_sdk_version', return_value='v0.1.0')
     @patch('intrinsic_sdk_bundle_library_py.build.run_command')
     @patch('os.path.exists', return_value=True)
-    def test_build_bundle_skill(self, mock_exists, mock_run_command, mock_get_version, mock_download):
+    def test_build_bundle_skill(
+        self, mock_exists, mock_run_command, mock_get_version, mock_download
+    ):
         args = MagicMock()
         args.service_name = None
         args.service_package = None
-        args.skill_name = "test_skill"
-        args.skill_package = "test_package"
-        args.manifest_path = "manifest.textproto"
-        args.images_dir = "./images"
+        args.skill_name = 'test_skill'
+        args.skill_package = 'test_package'
+        args.manifest_path = 'manifest.textproto'
+        args.images_dir = './images'
         args.default_config = None
 
         mock_run_command.return_value = MagicMock()
 
         build.build_bundle(args)
-        
+
         calls = mock_run_command.call_args_list
         found_bundle = False
         for call in calls:
@@ -97,22 +124,22 @@ class TestBuild(unittest.TestCase):
     @patch('intrinsic_sdk_bundle_library_py.build.run_command')
     def test_build_container_service(self, mock_run_command):
         args = MagicMock()
-        args.service_name = "test_service"
-        args.service_package = "test_package"
+        args.service_name = 'test_service'
+        args.service_package = 'test_package'
         args.skill_name = None
         args.skill_package = None
         args.dockerfile = None
-        args.images_dir = "./images"
-        args.builder_name = "test-builder"
+        args.images_dir = './images'
+        args.builder_name = 'test-builder'
         args.no_cache = False
-        args.ros_distro = "jazzy"
-        args.skill_type = "cpp"
+        args.ros_distro = 'jazzy'
+        args.skill_type = 'cpp'
         args.dependencies = None
 
         mock_run_command.return_value = MagicMock()
 
         build.build_container(args)
-        
+
         calls = mock_run_command.call_args_list
         found_build = False
         for call in calls:
@@ -126,20 +153,22 @@ class TestBuild(unittest.TestCase):
     @patch('intrinsic_sdk_bundle_library_py.build.get_sdk_version', return_value='v0.1.0')
     @patch('intrinsic_sdk_bundle_library_py.build.run_command')
     @patch('os.path.exists', return_value=True)
-    def test_build_bundle_service(self, mock_exists, mock_run_command, mock_get_version, mock_download):
+    def test_build_bundle_service(
+        self, mock_exists, mock_run_command, mock_get_version, mock_download
+    ):
         args = MagicMock()
-        args.service_name = "test_service"
-        args.service_package = "test_package"
+        args.service_name = 'test_service'
+        args.service_package = 'test_package'
         args.skill_name = None
         args.skill_package = None
-        args.manifest_path = "manifest.textproto"
-        args.images_dir = "./images"
+        args.manifest_path = 'manifest.textproto'
+        args.images_dir = './images'
         args.default_config = None
 
         mock_run_command.return_value = MagicMock()
 
         build.build_bundle(args)
-        
+
         calls = mock_run_command.call_args_list
         found_bundle = False
         for call in calls:
@@ -148,6 +177,7 @@ class TestBuild(unittest.TestCase):
                 found_bundle = True
                 break
         self.assertTrue(found_bundle)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/intrinsic_sdk_bundle_library_py/test/test_build.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_build.py
@@ -69,7 +69,7 @@ class TestBuild(unittest.TestCase):
         args.skill_name = 'test_skill'
         args.skill_package = 'test_package'
         args.dockerfile = None
-        args.images_dir = './images'
+        args.bundle_dir = './intrinsic_asset_bundles'
         args.builder_name = 'test-builder'
         args.no_cache = False
         args.ros_distro = 'jazzy'
@@ -89,6 +89,12 @@ class TestBuild(unittest.TestCase):
             args_list = call[0][0]
             if 'docker' in args_list and 'buildx' in args_list and 'build' in args_list:
                 found_build = True
+                output_idx = args_list.index('--output')
+                output_val = args_list[output_idx + 1]
+                self.assertIn(
+                    'dest=./intrinsic_asset_bundles/test_skill/test_skill.tar',
+                    output_val
+                )
                 break
         self.assertTrue(found_build)
 
@@ -106,7 +112,7 @@ class TestBuild(unittest.TestCase):
         args.skill_name = 'test_skill'
         args.skill_package = 'test_package'
         args.manifest_path = 'manifest.textproto'
-        args.images_dir = './images'
+        args.bundle_dir = './intrinsic_asset_bundles'
         args.default_config = None
 
         mock_run_command.return_value = MagicMock()
@@ -119,6 +125,11 @@ class TestBuild(unittest.TestCase):
             args_list = call[0][0]
             if './inbuild' in args_list and 'skill' in args_list and 'bundle' in args_list:
                 found_bundle = True
+                output_idx = args_list.index('--output')
+                self.assertEqual(
+                    args_list[output_idx + 1],
+                    './intrinsic_asset_bundles/test_skill/test_skill.bundle.tar'
+                )
                 break
         self.assertTrue(found_bundle)
 
@@ -130,7 +141,7 @@ class TestBuild(unittest.TestCase):
         args.skill_name = None
         args.skill_package = None
         args.dockerfile = None
-        args.images_dir = './images'
+        args.bundle_dir = './intrinsic_asset_bundles'
         args.builder_name = 'test-builder'
         args.no_cache = False
         args.ros_distro = 'jazzy'
@@ -147,6 +158,12 @@ class TestBuild(unittest.TestCase):
             args_list = call[0][0]
             if 'docker' in args_list and 'buildx' in args_list and 'build' in args_list:
                 found_build = True
+                output_idx = args_list.index('--output')
+                output_val = args_list[output_idx + 1]
+                self.assertIn(
+                    'dest=./intrinsic_asset_bundles/test_service/test_service.tar',
+                    output_val
+                )
                 break
         self.assertTrue(found_build)
 
@@ -164,7 +181,7 @@ class TestBuild(unittest.TestCase):
         args.skill_name = None
         args.skill_package = None
         args.manifest_path = 'manifest.textproto'
-        args.images_dir = './images'
+        args.bundle_dir = './intrinsic_asset_bundles'
         args.default_config = None
 
         mock_run_command.return_value = MagicMock()
@@ -177,6 +194,11 @@ class TestBuild(unittest.TestCase):
             args_list = call[0][0]
             if './inbuild' in args_list and 'service' in args_list and 'bundle' in args_list:
                 found_bundle = True
+                output_idx = args_list.index('--output')
+                self.assertEqual(
+                    args_list[output_idx + 1],
+                    './intrinsic_asset_bundles/test_service/test_service.bundle.tar'
+                )
                 break
         self.assertTrue(found_bundle)
 

--- a/intrinsic_sdk_bundle_library_py/test/test_build.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_build.py
@@ -92,12 +92,13 @@ class TestBuild(unittest.TestCase):
                 break
         self.assertTrue(found_build)
 
+    @patch('shutil.which', return_value=None)
     @patch('intrinsic_sdk_bundle_library_py.build.download_inbuild', return_value='./inbuild')
     @patch('intrinsic_sdk_bundle_library_py.build.get_sdk_version', return_value='v0.1.0')
     @patch('intrinsic_sdk_bundle_library_py.build.run_command')
     @patch('os.path.exists', return_value=True)
     def test_build_bundle_skill(
-        self, mock_exists, mock_run_command, mock_get_version, mock_download
+        self, mock_exists, mock_run_command, mock_get_version, mock_download, mock_which
     ):
         args = MagicMock()
         args.service_name = None
@@ -149,12 +150,13 @@ class TestBuild(unittest.TestCase):
                 break
         self.assertTrue(found_build)
 
+    @patch('shutil.which', return_value=None)
     @patch('intrinsic_sdk_bundle_library_py.build.download_inbuild', return_value='./inbuild')
     @patch('intrinsic_sdk_bundle_library_py.build.get_sdk_version', return_value='v0.1.0')
     @patch('intrinsic_sdk_bundle_library_py.build.run_command')
     @patch('os.path.exists', return_value=True)
     def test_build_bundle_service(
-        self, mock_exists, mock_run_command, mock_get_version, mock_download
+        self, mock_exists, mock_run_command, mock_get_version, mock_download, mock_which
     ):
         args = MagicMock()
         args.service_name = 'test_service'

--- a/intrinsic_sdk_bundle_library_py/test/test_colcon_verb.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_colcon_verb.py
@@ -113,7 +113,7 @@ class TestColconVerb(unittest.TestCase):
         mock_context = MagicMock()
         mock_context.args = argparse.Namespace(
             ros_distro='jazzy',
-            images_dir='./images',
+            bundle_dir='./intrinsic_asset_bundles',
             builder_name='container-builder',
             no_cache=False,
             keep_builder=False,

--- a/intrinsic_sdk_bundle_library_py/test/test_colcon_verb.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_colcon_verb.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Intrinsic Innovation LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+try:
+    from intrinsic_sdk_bundle_library_py.colcon_verb import BundleVerb
+except ImportError:
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    from intrinsic_sdk_bundle_library_py.colcon_verb import BundleVerb
+
+
+class TestColconVerb(unittest.TestCase):
+
+    def test_parse_manifest_skill_cpp(self):
+        verb = BundleVerb()
+        content = """id {
+          package: "com.example"
+          name: "test_cpp_skill"
+        }
+        options {
+          cc_config {
+            create_skill: "::TestCppSkill::CreateSkill"
+          }
+        }"""
+        info = verb._parse_manifest(content)
+        self.assertFalse(info['is_service'])
+        self.assertEqual(info['name'], 'test_cpp_skill')
+        self.assertEqual(info['package_org'], 'com.example')
+        self.assertEqual(info['skill_type'], 'cpp')
+
+    def test_parse_manifest_skill_python(self):
+        verb = BundleVerb()
+        content = """id {
+          package: "com.example"
+          name: "test_python_skill"
+        }
+        options {
+          python_config {
+            skill_module: "test_python_skill"
+          }
+        }"""
+        info = verb._parse_manifest(content)
+        self.assertFalse(info['is_service'])
+        self.assertEqual(info['name'], 'test_python_skill')
+        self.assertEqual(info['package_org'], 'com.example')
+        self.assertEqual(info['skill_type'], 'python')
+
+    def test_parse_manifest_service(self):
+        verb = BundleVerb()
+        content = """metadata {
+          id {
+            package: "ai.intrinsic"
+            name: "test_cpp_service"
+          }
+        }
+        service_def {
+          real_spec {}
+        }"""
+        info = verb._parse_manifest(content)
+        self.assertTrue(info['is_service'])
+        self.assertEqual(info['name'], 'test_cpp_service')
+        self.assertEqual(info['package_org'], 'ai.intrinsic')
+        self.assertIsNone(info['skill_type'])
+
+    @patch('intrinsic_sdk_bundle_library_py.colcon_verb.build_bundle')
+    @patch('intrinsic_sdk_bundle_library_py.colcon_verb.build_container')
+    @patch('intrinsic_sdk_bundle_library_py.colcon_verb.get_packages')
+    @patch('builtins.open', new_callable=mock_open, read_data=(
+        'id { package: "com.example" name: "my_skill" }\n'
+        'options { cc_config {} }'
+    ))
+    @patch('pathlib.Path.glob')
+    def test_main_with_skill(
+        self, mock_glob, mock_open_file, mock_get_packages,
+        mock_build_container, mock_build_bundle
+    ):
+        verb = BundleVerb()
+
+        # Mock colcon packages
+        mock_descriptor = MagicMock()
+        mock_descriptor.name = 'my_skill_pkg'
+        mock_descriptor.path = '/ws/src/my_skill_pkg'
+
+        mock_decorator = MagicMock()
+        mock_decorator.descriptor = mock_descriptor
+        mock_decorator.selected = True
+
+        mock_get_packages.return_value = [mock_decorator]
+
+        # Mock glob to find manifest
+        mock_glob.return_value = [
+            Path('/ws/src/my_skill_pkg/my_skill_pkg.manifest.textproto')
+        ]
+
+        # Mock context and args
+        mock_context = MagicMock()
+        mock_context.args = argparse.Namespace(
+            ros_distro='jazzy',
+            images_dir='./images',
+            builder_name='container-builder',
+            no_cache=False,
+            keep_builder=False,
+            default_config=None
+        )
+
+        result = verb.main(context=mock_context)
+        self.assertEqual(result, 0)
+
+        # Verify build_container call
+        mock_build_container.assert_called_once()
+        container_args = mock_build_container.call_args[0][0]
+        self.assertEqual(container_args.skill_name, 'my_skill')
+        self.assertEqual(container_args.skill_package, 'my_skill_pkg')
+        self.assertEqual(container_args.skill_type, 'cpp')
+        self.assertEqual(container_args.skill_asset_id_org, 'com.example')
+        self.assertIsNone(container_args.service_name)
+
+        # Verify build_bundle call
+        mock_build_bundle.assert_called_once()
+        bundle_args = mock_build_bundle.call_args[0][0]
+        self.assertEqual(bundle_args.skill_name, 'my_skill')
+        self.assertEqual(bundle_args.skill_package, 'my_skill_pkg')
+        self.assertEqual(
+            bundle_args.manifest_path,
+            str(Path('/ws/src/my_skill_pkg/my_skill_pkg.manifest.textproto').resolve())
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/intrinsic_sdk_bundle_library_py/test/test_copyright.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_copyright.py
@@ -19,5 +19,5 @@ import pytest
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
-    rc = main(argv=['.', 'test'])
+    rc = main(argv=['intrinsic_sdk_bundle_library_py', 'test/test_build.py', 'test/test_colcon_verb.py'])
     assert rc == 0, 'Found errors'

--- a/intrinsic_sdk_bundle_library_py/test/test_flake8.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_flake8.py
@@ -19,7 +19,7 @@ import pytest
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
-    rc, errors = main_with_errors(argv=[])
+    rc, errors = main_with_errors(argv=['intrinsic_sdk_bundle_library_py', 'test/test_build.py', 'test/test_colcon_verb.py'])
     assert rc == 0, \
         'Found %d code style errors / warnings:\n' % len(errors) + \
         '\n'.join(errors)

--- a/intrinsic_sdk_bundle_library_py/test/test_flake8.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_flake8.py
@@ -19,7 +19,12 @@ import pytest
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
-    rc, errors = main_with_errors(argv=['intrinsic_sdk_bundle_library_py', 'test/test_build.py', 'test/test_colcon_verb.py'])
+    rc, errors = main_with_errors(argv=[
+        'intrinsic_sdk_bundle_library_py',
+        'test/test_arguments.py',
+        'test/test_build.py',
+        'test/test_colcon_verb.py',
+    ])
     assert rc == 0, \
         'Found %d code style errors / warnings:\n' % len(errors) + \
         '\n'.join(errors)

--- a/intrinsic_sdk_bundle_library_py/test/test_pep257.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_pep257.py
@@ -19,5 +19,10 @@ import pytest
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
-    rc = main(argv=['intrinsic_sdk_bundle_library_py', 'test/test_build.py', 'test/test_colcon_verb.py'])
+    rc = main(argv=[
+        'intrinsic_sdk_bundle_library_py',
+        'test/test_arguments.py',
+        'test/test_build.py',
+        'test/test_colcon_verb.py',
+    ])
     assert rc == 0, 'Found code style errors / warnings'

--- a/intrinsic_sdk_bundle_library_py/test/test_pep257.py
+++ b/intrinsic_sdk_bundle_library_py/test/test_pep257.py
@@ -19,5 +19,5 @@ import pytest
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
-    rc = main(argv=['.', 'test'])
+    rc = main(argv=['intrinsic_sdk_bundle_library_py', 'test/test_build.py', 'test/test_colcon_verb.py'])
     assert rc == 0, 'Found code style errors / warnings'

--- a/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake.Dockerfile
+++ b/intrinsic_sdk_cmake/docker_images/intrinsic_sdk_cmake.Dockerfile
@@ -50,6 +50,10 @@ RUN \
     && apt-get update \
     && echo "python3-absl-py:" > /etc/ros/rosdep/custom.yaml \
     && echo "  ubuntu: [python3-absl]" >> /etc/ros/rosdep/custom.yaml \
+    && echo "colcon-core:" >> /etc/ros/rosdep/custom.yaml \
+    && echo "  ubuntu: [python3-colcon-core]" >> /etc/ros/rosdep/custom.yaml \
+    && echo "colcon-package-selection:" >> /etc/ros/rosdep/custom.yaml \
+    && echo "  ubuntu: [python3-colcon-package-selection]" >> /etc/ros/rosdep/custom.yaml \
     && echo "yaml file:///etc/ros/rosdep/custom.yaml" > /etc/ros/rosdep/sources.list.d/50-custom.list \
     && rosdep update --rosdistro jazzy \
     && cd /opt/intrinsic/intrinsic_sdk_cmake \


### PR DESCRIPTION
# Description
This PR implements and registers a new colcon bundle verb extension within the intrinsic_sdk_bundle_library_py package. The extension allows ROS 2 developers to build container images and package Intrinsic SDK bundles automatically across workspace packages.

# Key Changes
* New `colcon bundle` Verb: Automatically discovers ROS packages with `*.manifest.textproto` manifests, parses their package types, and orchestrates container and bundle builds.
* Refined Builder Logic: Added local/remote `inbuild` compiler download resolution, version tag mapping for developer SDK releases, and Dockerfile path resolution supporting symlinked assets.
* Workspace Integration and Dependency Management: Integrated container configurations with custom `rosdep` keys and registered the extension entry point via `setup.py`.
* Testing and Linting: Added  unit test coverage for the new colcon verb and fixed environment specific testing issues in `test_build.py`. Restricted pep257/flake8/copyright checkers to only scan the main package directories (excluding functional test directories).