### PR TITLE
get sdk version from intrinsic_sdk_bundle_library_py

### DIFF
--- a/.github/workflows/build_container_images.yaml
+++ b/.github/workflows/build_container_images.yaml
@@ -30,7 +30,12 @@ jobs:
 
       # Extract the intrinsic sdk version being used.
       - name: Get intrinsic-ai/sdk Version
-        run: echo "INTRINSIC_AI_SDK_VERSION=$(cat intrinsic_sdk_bundle_library_py/resource/sdk_version.json | jq -r '.sdk_version')" >> $GITHUB_ENV
+        run: echo "INTRINSIC_AI_SDK_VERSION=$(cat intrinsic_sdk_cmake/cmake/sdk_version.json | jq -r '.sdk_version')" >> $GITHUB_ENV
+      - run: |
+          if [ -z "$INTRINSIC_AI_SDK_VERSION" ]; then
+            echo "Error: INTRINSIC_AI_SDK_VERSION is empty!" >&2
+            exit 1
+          fi
       - run: echo "The Intrinsic SDK version being used is ${{ env.INTRINSIC_AI_SDK_VERSION }}"
       - id: intrinsic_ai_sdk_version
         run: echo "version=${{ env.INTRINSIC_AI_SDK_VERSION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_container_images.yaml
+++ b/.github/workflows/build_container_images.yaml
@@ -30,7 +30,7 @@ jobs:
 
       # Extract the intrinsic sdk version being used.
       - name: Get intrinsic-ai/sdk Version
-        run: echo "INTRINSIC_AI_SDK_VERSION=$(cat intrinsic_sdk_cmake/cmake/sdk_version.json | jq -r '.sdk_version')" >> $GITHUB_ENV
+        run: echo "INTRINSIC_AI_SDK_VERSION=$(cat intrinsic_sdk_bundle_library_py/resource/sdk_version.json | jq -r '.sdk_version')" >> $GITHUB_ENV
       - run: echo "The Intrinsic SDK version being used is ${{ env.INTRINSIC_AI_SDK_VERSION }}"
       - id: intrinsic_ai_sdk_version
         run: echo "version=${{ env.INTRINSIC_AI_SDK_VERSION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_container_images.yaml
+++ b/.github/workflows/build_container_images.yaml
@@ -30,7 +30,7 @@ jobs:
 
       # Extract the intrinsic sdk version being used.
       - name: Get intrinsic-ai/sdk Version
-        run: echo "INTRINSIC_AI_SDK_VERSION=$(cat intrinsic_sdk_cmake/cmake/sdk_version.json | jq -r '.sdk_version')" >> $GITHUB_ENV
+        run: echo "INTRINSIC_AI_SDK_VERSION=$(cat intrinsic_sdk_bundle_library_py/resource/sdk_version.json | jq -r '.sdk_version')" >> $GITHUB_ENV
       - run: |
           if [ -z "$INTRINSIC_AI_SDK_VERSION" ]; then
             echo "Error: INTRINSIC_AI_SDK_VERSION is empty!" >&2

--- a/.github/workflows/deploy_container_images.yaml
+++ b/.github/workflows/deploy_container_images.yaml
@@ -34,6 +34,11 @@ jobs:
       # Extract the intrinsic sdk version being used.
       - name: Get intrinsic-ai/sdk Version
         run: echo "INTRINSIC_AI_SDK_VERSION=${{ needs.build-test.outputs.intrinsic_ai_sdk_version }}" >> $GITHUB_ENV
+      - run: |
+          if [ -z "$INTRINSIC_AI_SDK_VERSION" ]; then
+            echo "Error: INTRINSIC_AI_SDK_VERSION is empty!" >&2
+            exit 1
+          fi
       - run: echo "The Intrinsic SDK version being used is ${{ env.INTRINSIC_AI_SDK_VERSION }}"
 
       # Login to ghcr.io.


### PR DESCRIPTION
Fix image deployment https://github.com/intrinsic-ai/sdk-ros/actions/workflows/deploy_container_images.yaml

* Use new location of `sdk_version.json` since https://github.com/intrinsic-ai/sdk-ros/pull/118.
* Catch that SDK version is not empty, https://github.com/intrinsic-ai/sdk-ros/actions/runs/28418260814/job/84205790773#step:8:10
<img width="572" height="158" alt="image" src="https://github.com/user-attachments/assets/7e79077d-2710-45ef-9142-51028f69a6ca" />

## Before 

<img width="572" height="158" alt="image" src="https://github.com/user-attachments/assets/b8817f3f-0377-459a-8c52-b32d59803458" />

In previous merge, https://github.com/intrinsic-ai/sdk-ros/pull/132, the SDK version was still missing https://github.com/intrinsic-ai/sdk-ros/actions/runs/28186745249/job/83490507481#step:8:7, hence it doesn't get propagated to the pushing step which only happens on main.

## After

<img width="590" height="126" alt="image" src="https://github.com/user-attachments/assets/063fdabc-ff56-4cde-a1ab-5069d1e8ef71" />
https://github.com/intrinsic-ai/sdk-ros/actions/runs/28417955102/job/84204845848?pr=134#step:8:7
