### PR TITLE
Add tool transform for FT sensor topic

### DIFF
--- a/flowstate_ros_bridge/flowstate_ros_bridge.proto
+++ b/flowstate_ros_bridge/flowstate_ros_bridge.proto
@@ -2,6 +2,15 @@ syntax = "proto3";
 
 package intrinsic;
 
+message ToolTransformationConfig {
+  double x = 1;
+  double y = 2;
+  double z = 3;
+  double roll = 4;
+  double pitch = 5;
+  double yaw = 6;
+}
+
 // Configuration to control which sensors are enabled to publish ROS 2 messages.
 // Robot state (joints) and force/torque sensor data.
 message SensorPublisherConfig {
@@ -14,6 +23,7 @@ message SensorPublisherConfig {
   string robot_controller_instance = 7;
   bool throttle_robot_state_topic = 8;
   repeated string override_joint_names = 9;
+  ToolTransformationConfig force_torque_tool_transform = 10;
 }
 
 message FlowstateRosBridgeConfig {

--- a/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
+++ b/flowstate_ros_bridge/flowstate_ros_bridge_default_config.pbtxt
@@ -27,6 +27,14 @@
     robot_controller_instance: "robot_controller"
     throttle_robot_state_topic: false
     override_joint_names: []
+    force_torque_tool_transform: {
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      roll: 0.0
+      pitch: 0.0
+      yaw: 0.0
+    }
   },
   align_tf_timestamps: true
 }

--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -50,7 +50,8 @@ constexpr const char* kThrottleRobotStateTopicParamName =
     "throttle_robot_state_topic";
 constexpr const char* kOverrideJointNamesParamName = "override_joint_names";
 constexpr const char* kAlignTfTimestampsParamName = "align_tf_timestamps";
-constexpr const char* kForceTorqueToolTransformParamName = "force_torque_tool_transform";
+constexpr const char* kForceTorqueToolTransformParamName =
+    "force_torque_tool_transform";
 
 ///=============================================================================
 void WorldBridge::declare_ros_parameters(
@@ -671,20 +672,18 @@ void WorldBridge::PublishForceTorqueSensor(
   wrench_msg.header.frame_id = frame_id;
 
   const auto& w = part_status.wrench_at_ft();
-  
+
   Eigen::Vector3d f_s(w.x(), w.y(), w.z());
   Eigen::Vector3d t_s(w.rx(), w.ry(), w.rz());
 
   // Apply tool transformation
   // Sensor wrench transformed to tool frame.
-  // Assuming transform is from sensor to tool: T_tool = T_sensor * ft_transform_matrix_
-  // Math: 
-  // F_t = R^T * F_s
-  // T_t = R^T * (T_s - r x F_s)
-  // where R is rotation from sensor to tool, and r is translation from sensor to tool in sensor frame.
-  // R = ft_transform_matrix_.linear()
-  // r = ft_transform_matrix_.translation()
-  
+  // Assuming transform is from sensor to tool: T_tool = T_sensor *
+  // ft_transform_matrix_ Math: F_t = R^T * F_s T_t = R^T * (T_s - r x F_s)
+  // where R is rotation from sensor to tool, and r is translation from sensor
+  // to tool in sensor frame. R = ft_transform_matrix_.linear() r =
+  // ft_transform_matrix_.translation()
+
   Eigen::Matrix3d R = data_->ft_transform_matrix_.linear();
   Eigen::Vector3d r = data_->ft_transform_matrix_.translation();
 

--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -50,6 +50,7 @@ constexpr const char* kThrottleRobotStateTopicParamName =
     "throttle_robot_state_topic";
 constexpr const char* kOverrideJointNamesParamName = "override_joint_names";
 constexpr const char* kAlignTfTimestampsParamName = "align_tf_timestamps";
+constexpr const char* kForceTorqueToolTransformParamName = "force_torque_tool_transform";
 
 ///=============================================================================
 void WorldBridge::declare_ros_parameters(
@@ -92,6 +93,9 @@ void WorldBridge::declare_ros_parameters(
   param_interface->declare_parameter(
       kOverrideJointNamesParamName,
       rclcpp::ParameterValue(std::vector<std::string>{}));
+  param_interface->declare_parameter(
+      kForceTorqueToolTransformParamName,
+      rclcpp::ParameterValue(std::vector<double>{0, 0, 0, 0, 0, 0}));
 }
 
 ///=============================================================================
@@ -176,6 +180,29 @@ bool WorldBridge::initialize(ROSNodeInterfaces ros_node_interfaces,
             << data_->robot_joint_state_topic_enabled_;
   LOG(INFO) << "Force Torque Bridge Enabled: "
             << data_->force_torque_topic_enabled_;
+
+  std::vector<double> ft_transform =
+      param_interface->get_parameter(kForceTorqueToolTransformParamName)
+          .as_double_array();
+  data_->ft_transform_matrix_ = Eigen::Isometry3d::Identity();
+  if (ft_transform.size() == 6) {
+    double x = ft_transform[0];
+    double y = ft_transform[1];
+    double z = ft_transform[2];
+    double roll = ft_transform[3] * M_PI / 180.0;
+    double pitch = ft_transform[4] * M_PI / 180.0;
+    double yaw = ft_transform[5] * M_PI / 180.0;
+
+    data_->ft_transform_matrix_.translation() = Eigen::Vector3d(x, y, z);
+    Eigen::AngleAxisd rollAngle(roll, Eigen::Vector3d::UnitX());
+    Eigen::AngleAxisd pitchAngle(pitch, Eigen::Vector3d::UnitY());
+    Eigen::AngleAxisd yawAngle(yaw, Eigen::Vector3d::UnitZ());
+    Eigen::Quaterniond q = yawAngle * pitchAngle * rollAngle;
+    data_->ft_transform_matrix_.linear() = q.matrix();
+  } else {
+    LOG(WARNING) << "Invalid force_torque_tool_transform size! Expected 6, got "
+                 << ft_transform.size() << ". Using identity transform.";
+  }
 
   // Create ROS publishers
   data_->robot_joint_state_pub_ =
@@ -644,12 +671,32 @@ void WorldBridge::PublishForceTorqueSensor(
   wrench_msg.header.frame_id = frame_id;
 
   const auto& w = part_status.wrench_at_ft();
-  wrench_msg.wrench.force.x = w.x();
-  wrench_msg.wrench.force.y = w.y();
-  wrench_msg.wrench.force.z = w.z();
-  wrench_msg.wrench.torque.x = w.rx();
-  wrench_msg.wrench.torque.y = w.ry();
-  wrench_msg.wrench.torque.z = w.rz();
+  
+  Eigen::Vector3d f_s(w.x(), w.y(), w.z());
+  Eigen::Vector3d t_s(w.rx(), w.ry(), w.rz());
+
+  // Apply tool transformation
+  // Sensor wrench transformed to tool frame.
+  // Assuming transform is from sensor to tool: T_tool = T_sensor * ft_transform_matrix_
+  // Math: 
+  // F_t = R^T * F_s
+  // T_t = R^T * (T_s - r x F_s)
+  // where R is rotation from sensor to tool, and r is translation from sensor to tool in sensor frame.
+  // R = ft_transform_matrix_.linear()
+  // r = ft_transform_matrix_.translation()
+  
+  Eigen::Matrix3d R = data_->ft_transform_matrix_.linear();
+  Eigen::Vector3d r = data_->ft_transform_matrix_.translation();
+
+  Eigen::Vector3d f_t = R.transpose() * f_s;
+  Eigen::Vector3d t_t = R.transpose() * (t_s - r.cross(f_s));
+
+  wrench_msg.wrench.force.x = f_t.x();
+  wrench_msg.wrench.force.y = f_t.y();
+  wrench_msg.wrench.force.z = f_t.z();
+  wrench_msg.wrench.torque.x = t_t.x();
+  wrench_msg.wrench.torque.y = t_t.y();
+  wrench_msg.wrench.torque.z = t_t.z();
 
   data_->force_torque_pub_->publish(wrench_msg);
 }

--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -195,10 +195,10 @@ bool WorldBridge::initialize(ROSNodeInterfaces ros_node_interfaces,
     double yaw = ft_transform[5] * M_PI / 180.0;
 
     data_->ft_transform_matrix_.translation() = Eigen::Vector3d(x, y, z);
-    Eigen::AngleAxisd rollAngle(roll, Eigen::Vector3d::UnitX());
-    Eigen::AngleAxisd pitchAngle(pitch, Eigen::Vector3d::UnitY());
-    Eigen::AngleAxisd yawAngle(yaw, Eigen::Vector3d::UnitZ());
-    Eigen::Quaterniond q = yawAngle * pitchAngle * rollAngle;
+# Use the ZYX convention
+Eigen::Quaterniond q = Eigen::AngleAxisd(yaw, Eigen::Vector3d::UnitZ())
+                     * Eigen::AngleAxisd(pitch, Eigen::Vector3d::UnitY())
+                     * Eigen::AngleAxisd(roll, Eigen::Vector3d::UnitX());
     data_->ft_transform_matrix_.linear() = q.matrix();
   } else {
     LOG(WARNING) << "Invalid force_torque_tool_transform size! Expected 6, got "

--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -676,13 +676,22 @@ void WorldBridge::PublishForceTorqueSensor(
   Eigen::Vector3d f_s(w.x(), w.y(), w.z());
   Eigen::Vector3d t_s(w.rx(), w.ry(), w.rz());
 
-  // Apply tool transformation
-  // Sensor wrench transformed to tool frame.
-  // Assuming transform is from sensor to tool: T_tool = T_sensor *
-  // ft_transform_matrix_ Math: F_t = R^T * F_s T_t = R^T * (T_s - r x F_s)
-  // where R is rotation from sensor to tool, and r is translation from sensor
-  // to tool in sensor frame. R = ft_transform_matrix_.linear() r =
-  // ft_transform_matrix_.translation()
+  /**
+   * Transform the wrench from sensor frame to tool frame.
+   * 
+   * Transformation ft_transform_matrix_ is from sensor to tool frame,
+   * Then the tool transformation T_tool can be expressed as: 
+   *  T_tool = T_sensor * ft_transform_matrix_ 
+   * 
+   * Linear part of wrench: F_t = R.transpose() * F_s 
+   * Torque part of wrench: T_t = R.transpose() * (T_s - r.cross(F_s))
+   * 
+   * Where 
+   * R is rotation from sensor to tool
+   *    R = ft_transform_matrix_.linear()
+   * r is translation from sensor to tool in sensor frame, 
+   *    r = ft_transform_matrix_.translation()
+   */
 
   Eigen::Matrix3d R = data_->ft_transform_matrix_.linear();
   Eigen::Vector3d r = data_->ft_transform_matrix_.translation();

--- a/flowstate_ros_bridge/src/bridges/world_bridge.cpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.cpp
@@ -195,10 +195,11 @@ bool WorldBridge::initialize(ROSNodeInterfaces ros_node_interfaces,
     double yaw = ft_transform[5] * M_PI / 180.0;
 
     data_->ft_transform_matrix_.translation() = Eigen::Vector3d(x, y, z);
-# Use the ZYX convention
-Eigen::Quaterniond q = Eigen::AngleAxisd(yaw, Eigen::Vector3d::UnitZ())
-                     * Eigen::AngleAxisd(pitch, Eigen::Vector3d::UnitY())
-                     * Eigen::AngleAxisd(roll, Eigen::Vector3d::UnitX());
+
+    // Use the ZYX convention
+    Eigen::Quaterniond q = Eigen::AngleAxisd(yaw, Eigen::Vector3d::UnitZ()) *
+                           Eigen::AngleAxisd(pitch, Eigen::Vector3d::UnitY()) *
+                           Eigen::AngleAxisd(roll, Eigen::Vector3d::UnitX());
     data_->ft_transform_matrix_.linear() = q.matrix();
   } else {
     LOG(WARNING) << "Invalid force_torque_tool_transform size! Expected 6, got "
@@ -678,18 +679,18 @@ void WorldBridge::PublishForceTorqueSensor(
 
   /**
    * Transform the wrench from sensor frame to tool frame.
-   * 
+   *
    * Transformation ft_transform_matrix_ is from sensor to tool frame,
-   * Then the tool transformation T_tool can be expressed as: 
-   *  T_tool = T_sensor * ft_transform_matrix_ 
-   * 
-   * Linear part of wrench: F_t = R.transpose() * F_s 
+   * Then the tool transformation T_tool can be expressed as:
+   *  T_tool = T_sensor * ft_transform_matrix_
+   *
+   * Linear part of wrench: F_t = R.transpose() * F_s
    * Torque part of wrench: T_t = R.transpose() * (T_s - r.cross(F_s))
-   * 
-   * Where 
+   *
+   * Where
    * R is rotation from sensor to tool
    *    R = ft_transform_matrix_.linear()
-   * r is translation from sensor to tool in sensor frame, 
+   * r is translation from sensor to tool in sensor frame,
    *    r = ft_transform_matrix_.translation()
    */
 

--- a/flowstate_ros_bridge/src/bridges/world_bridge.hpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.hpp
@@ -15,9 +15,9 @@
 #ifndef BRIDGES__WORLD_BRIDGE_HPP_
 #define BRIDGES__WORLD_BRIDGE_HPP_
 
+#include <Eigen/Geometry>
 #include <memory>
 #include <thread>
-#include <Eigen/Geometry>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"

--- a/flowstate_ros_bridge/src/bridges/world_bridge.hpp
+++ b/flowstate_ros_bridge/src/bridges/world_bridge.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <thread>
+#include <Eigen/Geometry>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
@@ -100,6 +101,7 @@ class WorldBridge : public BridgeInterface {
     bool robot_joint_state_topic_enabled_;
     bool force_torque_topic_enabled_;
     std::string ft_sensor_frame_id_;
+    Eigen::Isometry3d ft_transform_matrix_;
     std::string robot_base_frame_id_;
     // Cached part names to avoid repeated map iteration
     std::optional<std::string> robot_arm_part_name_;

--- a/flowstate_ros_bridge/src/flowstate_ros_bridge_main.cpp
+++ b/flowstate_ros_bridge/src/flowstate_ros_bridge_main.cpp
@@ -126,19 +126,17 @@ int main(int argc, char* argv[]) {
   params.emplace_back("override_joint_names", override_joint_names);
 
   if (s.has_force_torque_tool_transform()) {
-    std::vector<double> ft_transform = {
-        s.force_torque_tool_transform().x(),
-        s.force_torque_tool_transform().y(),
-        s.force_torque_tool_transform().z(),
-        s.force_torque_tool_transform().roll(),
-        s.force_torque_tool_transform().pitch(),
-        s.force_torque_tool_transform().yaw()
-    };
+    std::vector<double> ft_transform = {s.force_torque_tool_transform().x(),
+                                        s.force_torque_tool_transform().y(),
+                                        s.force_torque_tool_transform().z(),
+                                        s.force_torque_tool_transform().roll(),
+                                        s.force_torque_tool_transform().pitch(),
+                                        s.force_torque_tool_transform().yaw()};
     params.emplace_back("force_torque_tool_transform", ft_transform);
   } else {
-    params.emplace_back("force_torque_tool_transform", std::vector<double>{0, 0, 0, 0, 0, 0});
+    params.emplace_back("force_torque_tool_transform",
+                        std::vector<double>{0, 0, 0, 0, 0, 0});
   }
-
 
   options.parameter_overrides(params);
 

--- a/flowstate_ros_bridge/src/flowstate_ros_bridge_main.cpp
+++ b/flowstate_ros_bridge/src/flowstate_ros_bridge_main.cpp
@@ -125,6 +125,21 @@ int main(int argc, char* argv[]) {
       override_joint_names_proto.begin(), override_joint_names_proto.end());
   params.emplace_back("override_joint_names", override_joint_names);
 
+  if (s.has_force_torque_tool_transform()) {
+    std::vector<double> ft_transform = {
+        s.force_torque_tool_transform().x(),
+        s.force_torque_tool_transform().y(),
+        s.force_torque_tool_transform().z(),
+        s.force_torque_tool_transform().roll(),
+        s.force_torque_tool_transform().pitch(),
+        s.force_torque_tool_transform().yaw()
+    };
+    params.emplace_back("force_torque_tool_transform", ft_transform);
+  } else {
+    params.emplace_back("force_torque_tool_transform", std::vector<double>{0, 0, 0, 0, 0, 0});
+  }
+
+
   options.parameter_overrides(params);
 
   // Get namespace from config


### PR DESCRIPTION
## Summary
This PR introduces the ability to configure a static 6-DoF tool transformation for Force/Torque sensor readings before they are published to ROS. 

Previously, the `WorldBridge` plugin published the raw F/T sensor wrench exactly as streamed from the ICON `PartStatus`, which is natively aligned with the physical sensor's flange. This change allows users to define a virtual tool center point (TCP) offset and orientation in their config, mathematically projecting the wrench into a designated tool frame (e.g. `ati/tool_link`) prior to publishing the `WrenchStamped` message.

## Changes
* **`flowstate_ros_bridge.proto`**: Added a new `ToolTransformationConfig` message containing translation (`x, y, z` in meters) and orientation (`roll, pitch, yaw` in degrees) fields. Added this as `force_torque_tool_transform` in the `SensorPublisherConfig`.
* **`flowstate_ros_bridge_main.cpp`**: Added parsing logic to extract the tool transform from the proto config. If present, it forwards the values as a 6-element `std::vector<double>` ROS parameter named `force_torque_tool_transform`. Falls back to an identity transform (zeros) if omitted.
* **`world_bridge.hpp` / `world_bridge.cpp`**: 
  * Declared the new `force_torque_tool_transform` parameter.
  * Updated `PublishForceTorqueSensor` to mathematically apply the tool transform. The torque is first shifted by the translation vector (`T_new = T_sensor - r × F_sensor`), and then both force and torque are rotated into the new tool coordinate frame using the inverse rotation matrix (`R.transpose()`).