### PR TITLE
Bump SDK to `v1.35.20260720`.

### DIFF
--- a/intrinsic_sdk_bundle_library_py/resource/sdk_version.json
+++ b/intrinsic_sdk_bundle_library_py/resource/sdk_version.json
@@ -1,4 +1,4 @@
 {
-	"sdk_version": "v1.33.20260608",
-	"sdk_checksum": "SHA256=a7eaf287db2415826025fdeac3cb0fa54aa0f0893eb4f278f54e7c0905eca185"
+	"sdk_version": "v1.35.20260720",
+	"sdk_checksum": "SHA256=649b4911cf9bf30093009eff5200fb154b01c64ec7ff1fe359e44f8482a73363"
 }

--- a/intrinsic_sdk_bundle_library_py/test/functional_tests/test_cpp_skill/CMakeLists.txt
+++ b/intrinsic_sdk_bundle_library_py/test/functional_tests/test_cpp_skill/CMakeLists.txt
@@ -38,6 +38,7 @@ intrinsic_sdk_generate_skill_main_cc(
   MANIFEST test_cpp_skill.manifest.textproto
   HEADER_FILES test_cpp_skill.h
   MAIN_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_cpp_skill_main.cc"
+  FILE_DESCRIPTOR_SET "${CMAKE_CURRENT_BINARY_DIR}/test_cpp_skill.desc"
 )
 
 # Build the skill main.

--- a/intrinsic_sdk_cmake/cmake/api/skill/intrinsic_sdk_generate_skill_config.cmake
+++ b/intrinsic_sdk_cmake/cmake/api/skill/intrinsic_sdk_generate_skill_config.cmake
@@ -77,9 +77,16 @@ function(intrinsic_sdk_generate_skill_config)
     # COMMAND intrinsic_sdk_cmake::inbuild
     COMMAND inbuild_import
     ARGS
-      skill generate config
+      skill manifest
       --manifest=${manifest_textproto}
-      --file_descriptor_set=${arg_PROTO_DESCRIPTOR_FILE}
+      --file_descriptor_sets=${arg_PROTO_DESCRIPTOR_FILE}
+      --output=${CMAKE_CURRENT_BINARY_DIR}/${arg_TARGET}_augmented_manifest.pbbin
+      --file_descriptor_set_out=${CMAKE_CURRENT_BINARY_DIR}/${arg_TARGET}_augmented_protos.desc
+    COMMAND inbuild_import
+    ARGS
+      skill generate config
+      --augmented_manifest=${CMAKE_CURRENT_BINARY_DIR}/${arg_TARGET}_augmented_manifest.pbbin
+      --augmented_file_descriptor_set=${CMAKE_CURRENT_BINARY_DIR}/${arg_TARGET}_augmented_protos.desc
       --output=${arg_SKILL_CONFIG_FILE_OUTPUT}
     COMMENT "Generating skill config for ${arg_SKILL_NAME}"
     DEPENDS

--- a/intrinsic_sdk_cmake/cmake/api/skill/intrinsic_sdk_generate_skill_main_cc.cmake
+++ b/intrinsic_sdk_cmake/cmake/api/skill/intrinsic_sdk_generate_skill_main_cc.cmake
@@ -39,7 +39,7 @@ include_guard(GLOBAL)
 #
 function(intrinsic_sdk_generate_skill_main_cc)
   set(options)
-  set(one_value_args MANIFEST_PBBIN MANIFEST MAIN_FILE_OUTPUT)
+  set(one_value_args MANIFEST_PBBIN MANIFEST MAIN_FILE_OUTPUT FILE_DESCRIPTOR_SET)
   set(multi_value_args HEADER_FILES)
 
   cmake_parse_arguments(
@@ -69,8 +69,15 @@ function(intrinsic_sdk_generate_skill_main_cc)
   endif()
   list(JOIN arg_HEADER_FILES "," joined_header_files)
 
+  if(NOT arg_FILE_DESCRIPTOR_SET)
+    set(arg_FILE_DESCRIPTOR_SET "${arg_MAIN_FILE_OUTPUT}_empty.desc")
+    file(WRITE "${arg_FILE_DESCRIPTOR_SET}" "")
+  endif()
+
   add_custom_command(
     OUTPUT ${arg_MAIN_FILE_OUTPUT}
+           ${arg_MAIN_FILE_OUTPUT}_augmented_manifest.pbbin
+           ${arg_MAIN_FILE_OUTPUT}_augmented_protos.desc
     # TODO(wjwwood): figure out why the alias does not work...
     # COMMAND intrinsic_sdk_cmake::inbuild
     COMMAND inbuild_import
@@ -79,6 +86,9 @@ function(intrinsic_sdk_generate_skill_main_cc)
       --language=cpp
       --output=${arg_MAIN_FILE_OUTPUT}
       --cc_header=${joined_header_files}
+      --file_descriptor_set=${arg_FILE_DESCRIPTOR_SET}
+      --augmented_manifest_out=${arg_MAIN_FILE_OUTPUT}_augmented_manifest.pbbin
+      --augmented_file_descriptor_set_out=${arg_MAIN_FILE_OUTPUT}_augmented_protos.desc
     DEPENDS ${manifest_textproto}
     COMMENT "Generating skill cpp main file: ${arg_MAIN_FILE_OUTPUT}"
   )

--- a/intrinsic_sdk_cmake/test/test_cpp_skill/CMakeLists.txt
+++ b/intrinsic_sdk_cmake/test/test_cpp_skill/CMakeLists.txt
@@ -32,6 +32,7 @@ intrinsic_sdk_generate_skill_main_cc(
   MANIFEST test_cpp_skill.manifest.textproto
   HEADER_FILES test_cpp_skill.h
   MAIN_FILE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_cpp_skill_main.cc"
+  FILE_DESCRIPTOR_SET "${CMAKE_CURRENT_BINARY_DIR}/test_cpp_skill.desc"
 )
 
 # Build the skill main.


### PR DESCRIPTION
#### Changes
- Update SDK version to `v1.35.20260720`.
- Update to latest `inbuild skill manifest` generation. 
  - Add default descriptor arg to make backward-compatible with breaking change from https://flowstate.intrinsic.ai/docs/learn/release_notes/#version-133-june-29th-2026.