### PR TITLE
Fix linter test lyrical

### DIFF
--- a/flowstate_interfaces/CMakeLists.txt
+++ b/flowstate_interfaces/CMakeLists.txt
@@ -38,7 +38,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES
     action_msgs
     builtin_interfaces
-  ADD_LINTER_TESTS
 )
 
 ament_export_dependencies(rosidl_default_runtime)


### PR DESCRIPTION
#### Changes
- Remove failing linter tests for generated `flowstate_interfaces` when running `colcon test`.

#### Reproducing failure
- With ROS 2 Lyrical, build SDK-ROS with `colcon build`.
- Run `colcon test`.
- Get error:
```shell
build/flowstate_interfaces/Testing/20260806-2206/Test.xml: 30 tests, 0 errors, 1 failure, 0 skipped
- cpplint_rosidl_generated_py
  <<< failure message
    -- run_test.py: invoking following command in '.../src/intrinsic-ai/sdk-ros/flowstate_interfaces':
     - .../.pixi/envs/default/bin/ament_cpplint --xunit-file .../build/flowstate_interfaces/test_results/flowstate_interfaces/cpplint_rosidl_generated_py.xunit.xml --filters=-readability/fn_size --linelength 999 --root .../build/flowstate_interfaces/rosidl_generator_py .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces
    DEBUG: Using '--root=.../build/flowstate_interfaces/rosidl_generator_py' argument
   .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/srv/_get_resource_s.c:149:  Found C system header after other header. Should be: _get_resource_s.h, c system, c++ system, other.  [build/include_order] [4]
    Done processing .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/_flowstate_interfaces_s.ep.rosidl_typesupport_c.c
    Done processing .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/_flowstate_interfaces_s.ep.rosidl_typesupport_fastrtps_c.c
    Done processing .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/_flowstate_interfaces_s.ep.rosidl_typesupport_introspection_c.c
    Done processing .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/action/_start_process_s.c
    Done processing .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/msg/_behavior_tree_s.c
    Done processing .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/msg/_execution_mode_s.c
    Done processing .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/msg/_simulation_mode_s.c
    Done processing .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/srv/_get_resource_s.c
    Done processing .../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/srv/_list_behavior_trees_s.c
    INFO: Category build/include_order errors found: 1
    INFO: Total errors found: 1
    -- run_test.py: return code 1
    -- run_test.py: verify result file '.../build/flowstate_interfaces/test_results/flowstate_interfaces/cpplint_rosidl_generated_py.xunit.xml'
  >>>
build/flowstate_interfaces/test_results/flowstate_interfaces/cpplint_rosidl_generated_py.xunit.xml: 9 tests, 0 errors, 1 failure, 0 skipped
- flowstate_interfaces.cpplint_rosidl_generated_py build/include_order [4] (.../build/flowstate_interfaces/rosidl_generator_py/flowstate_interfaces/srv/_get_resource_s.c:149)
  <<< failure message
    Found C system header after other header. Should be: _get_resource_s.h, c system, c++ system, other.
  >>>
``
